### PR TITLE
Smarter JS temp naming, fixes #136

### DIFF
--- a/lib/runtime/dart/_interceptors.js
+++ b/lib/runtime/dart/_interceptors.js
@@ -854,8 +854,8 @@ var _interceptors;
   JSString[dart.implements] = () => [core.String, JSIndexable];
   let _string = Symbol('_string');
   class _CodeUnits extends _internal.UnmodifiableListBase$(core.int) {
-    _CodeUnits(string$) {
-      this[_string] = string$;
+    _CodeUnits(string) {
+      this[_string] = string;
       super.UnmodifiableListBase();
     }
     get [core.$length]() {

--- a/lib/runtime/dart/_internal.js
+++ b/lib/runtime/dart/_internal.js
@@ -229,9 +229,9 @@ var _internal;
   let _startIndex = dart.JsSymbol('_startIndex');
   let SubListIterable$ = dart.generic(function(E) {
     class SubListIterable extends ListIterable$(E) {
-      SubListIterable(iterable$, start$, endOrLength) {
-        this[_iterable] = iterable$;
-        this[_start] = start$;
+      SubListIterable(iterable, start, endOrLength) {
+        this[_iterable] = iterable;
+        this[_start] = start;
         this[_endOrLength] = endOrLength;
         super.ListIterable();
         core.RangeError.checkNotNegative(this[_start], "start");
@@ -361,9 +361,9 @@ var _internal;
         }
         return new MappedIterable$(S, T)[_](dart.as(iterable, core.Iterable$(S)), func);
       }
-      [_](iterable$, f$) {
-        this[_iterable] = iterable$;
-        this[_f] = f$;
+      [_](iterable, f) {
+        this[_iterable] = iterable;
+        this[_f] = f;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -405,9 +405,9 @@ var _internal;
   let _iterator = dart.JsSymbol('_iterator');
   let MappedIterator$ = dart.generic(function(S, T) {
     class MappedIterator extends core.Iterator$(T) {
-      MappedIterator(iterator$, f$) {
-        this[_iterator] = iterator$;
-        this[_f] = f$;
+      MappedIterator(iterator, f) {
+        this[_iterator] = iterator;
+        this[_f] = f;
         this[_current] = null;
         super.Iterator();
       }
@@ -429,9 +429,9 @@ var _internal;
   let _source = dart.JsSymbol('_source');
   let MappedListIterable$ = dart.generic(function(S, T) {
     class MappedListIterable extends ListIterable$(T) {
-      MappedListIterable(source, f$) {
+      MappedListIterable(source, f) {
         this[_source] = source;
-        this[_f] = f$;
+        this[_f] = f;
         super.ListIterable();
       }
       get [core.$length]() {
@@ -452,9 +452,9 @@ var _internal;
   let _ElementPredicate = _ElementPredicate$();
   let WhereIterable$ = dart.generic(function(E) {
     class WhereIterable extends collection.IterableBase$(E) {
-      WhereIterable(iterable$, f$) {
-        this[_iterable] = iterable$;
-        this[_f] = f$;
+      WhereIterable(iterable, f) {
+        this[_iterable] = iterable;
+        this[_f] = f;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -466,9 +466,9 @@ var _internal;
   let WhereIterable = WhereIterable$();
   let WhereIterator$ = dart.generic(function(E) {
     class WhereIterator extends core.Iterator$(E) {
-      WhereIterator(iterator$, f$) {
-        this[_iterator] = iterator$;
-        this[_f] = f$;
+      WhereIterator(iterator, f) {
+        this[_iterator] = iterator;
+        this[_f] = f;
         super.Iterator();
       }
       moveNext() {
@@ -493,9 +493,9 @@ var _internal;
   let _ExpandFunction = _ExpandFunction$();
   let ExpandIterable$ = dart.generic(function(S, T) {
     class ExpandIterable extends collection.IterableBase$(T) {
-      ExpandIterable(iterable$, f$) {
-        this[_iterable] = iterable$;
-        this[_f] = f$;
+      ExpandIterable(iterable, f) {
+        this[_iterable] = iterable;
+        this[_f] = f;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -509,9 +509,9 @@ var _internal;
   let _nextExpansion = dart.JsSymbol('_nextExpansion');
   let ExpandIterator$ = dart.generic(function(S, T) {
     class ExpandIterator extends core.Object {
-      ExpandIterator(iterator$, f$) {
-        this[_iterator] = iterator$;
-        this[_f] = f$;
+      ExpandIterator(iterator, f) {
+        this[_iterator] = iterator;
+        this[_f] = f;
         this[_currentExpansion] = dart.as(new EmptyIterator(), core.Iterator$(T));
         this[_current] = null;
       }
@@ -551,9 +551,9 @@ var _internal;
         }
         return new TakeIterable$(E)[_](iterable, takeCount);
       }
-      [_](iterable$, takeCount$) {
-        this[_iterable] = iterable$;
-        this[_takeCount] = takeCount$;
+      [_](iterable, takeCount) {
+        this[_iterable] = iterable;
+        this[_takeCount] = takeCount;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -583,8 +583,8 @@ var _internal;
   let _remaining = dart.JsSymbol('_remaining');
   let TakeIterator$ = dart.generic(function(E) {
     class TakeIterator extends core.Iterator$(E) {
-      TakeIterator(iterator$, remaining) {
-        this[_iterator] = iterator$;
+      TakeIterator(iterator, remaining) {
+        this[_iterator] = iterator;
         this[_remaining] = remaining;
         super.Iterator();
         dart.assert(typeof this[_remaining] == 'number' && dart.notNull(this[_remaining]) >= 0);
@@ -608,9 +608,9 @@ var _internal;
   let TakeIterator = TakeIterator$();
   let TakeWhileIterable$ = dart.generic(function(E) {
     class TakeWhileIterable extends collection.IterableBase$(E) {
-      TakeWhileIterable(iterable$, f$) {
-        this[_iterable] = iterable$;
-        this[_f] = f$;
+      TakeWhileIterable(iterable, f) {
+        this[_iterable] = iterable;
+        this[_f] = f;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -623,9 +623,9 @@ var _internal;
   let _isFinished = dart.JsSymbol('_isFinished');
   let TakeWhileIterator$ = dart.generic(function(E) {
     class TakeWhileIterator extends core.Iterator$(E) {
-      TakeWhileIterator(iterator$, f$) {
-        this[_iterator] = iterator$;
-        this[_f] = f$;
+      TakeWhileIterator(iterator, f) {
+        this[_iterator] = iterator;
+        this[_f] = f;
         this[_isFinished] = false;
         super.Iterator();
       }
@@ -656,9 +656,9 @@ var _internal;
         }
         return new SkipIterable$(E)[_](iterable, count);
       }
-      [_](iterable$, skipCount$) {
-        this[_iterable] = iterable$;
-        this[_skipCount] = skipCount$;
+      [_](iterable, skipCount) {
+        this[_iterable] = iterable;
+        this[_skipCount] = skipCount;
         super.IterableBase();
         if (!(typeof this[_skipCount] == 'number')) {
           throw new core.ArgumentError.value(this[_skipCount], "count is not an integer");
@@ -698,9 +698,9 @@ var _internal;
   let EfficientLengthSkipIterable = EfficientLengthSkipIterable$();
   let SkipIterator$ = dart.generic(function(E) {
     class SkipIterator extends core.Iterator$(E) {
-      SkipIterator(iterator$, skipCount$) {
-        this[_iterator] = iterator$;
-        this[_skipCount] = skipCount$;
+      SkipIterator(iterator, skipCount) {
+        this[_iterator] = iterator;
+        this[_skipCount] = skipCount;
         super.Iterator();
         dart.assert(typeof this[_skipCount] == 'number' && dart.notNull(this[_skipCount]) >= 0);
       }
@@ -719,9 +719,9 @@ var _internal;
   let SkipIterator = SkipIterator$();
   let SkipWhileIterable$ = dart.generic(function(E) {
     class SkipWhileIterable extends collection.IterableBase$(E) {
-      SkipWhileIterable(iterable$, f$) {
-        this[_iterable] = iterable$;
-        this[_f] = f$;
+      SkipWhileIterable(iterable, f) {
+        this[_iterable] = iterable;
+        this[_f] = f;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -734,9 +734,9 @@ var _internal;
   let _hasSkipped = dart.JsSymbol('_hasSkipped');
   let SkipWhileIterator$ = dart.generic(function(E) {
     class SkipWhileIterator extends core.Iterator$(E) {
-      SkipWhileIterator(iterator$, f$) {
-        this[_iterator] = iterator$;
-        this[_f] = f$;
+      SkipWhileIterator(iterator, f) {
+        this[_iterator] = iterator;
+        this[_f] = f;
         this[_hasSkipped] = false;
         super.Iterator();
       }
@@ -1839,8 +1839,8 @@ var _internal;
     Symbol(name) {
       this[_name] = name;
     }
-    unvalidated(name$) {
-      this[_name] = name$;
+    unvalidated(name) {
+      this[_name] = name;
     }
     validated(name) {
       this[_name] = Symbol.validatePublicSymbol(name);

--- a/lib/runtime/dart/_isolate_helper.js
+++ b/lib/runtime/dart/_isolate_helper.js
@@ -350,21 +350,21 @@ var _isolate_helper;
     }
   }
   // Function _callInIsolate: (_IsolateContext, Function) → dynamic
-  function _callInIsolate(isolate, function$0) {
-    let result = isolate.eval(function$0);
+  function _callInIsolate(isolate, func) {
+    let result = isolate.eval(func);
     exports._globalState.topEventLoop.run();
     return result;
   }
   let _activeJsAsyncCount = Symbol('_activeJsAsyncCount');
   // Function enterJsAsync: () → dynamic
   function enterJsAsync() {
-    let o$ = exports._globalState.topEventLoop;
-    o$[_activeJsAsyncCount] = dart.notNull(o$[_activeJsAsyncCount]) + 1;
+    let o = exports._globalState.topEventLoop;
+    o[_activeJsAsyncCount] = dart.notNull(o[_activeJsAsyncCount]) + 1;
   }
   // Function leaveJsAsync: () → dynamic
   function leaveJsAsync() {
-    let o$ = exports._globalState.topEventLoop;
-    o$[_activeJsAsyncCount] = dart.notNull(o$[_activeJsAsyncCount]) - 1;
+    let o = exports._globalState.topEventLoop;
+    o[_activeJsAsyncCount] = dart.notNull(o[_activeJsAsyncCount]) - 1;
     dart.assert(dart.notNull(exports._globalState.topEventLoop[_activeJsAsyncCount]) >= 0);
   }
   // Function isWorker: () → bool
@@ -449,12 +449,12 @@ var _isolate_helper;
       this.fromCommandLine = !dart.notNull(isWindowDefined) && !dart.notNull(this.isWorker);
     }
     [_nativeInitWorkerMessageHandler]() {
-      let function$0 = function(f, a) {
+      let func = function(f, a) {
         return function(e) {
           f(a, e);
         };
       }(_foreign_helper.DART_CLOSURE_TO_JS(IsolateNatives[_processWorkerMessage]), this.mainManager);
-      self.onmessage = function$0;
+      self.onmessage = func;
       self.dartPrint = self.dartPrint || function(serialize) {
         return function(object) {
           if (self.console && self.console.log) {
@@ -484,9 +484,9 @@ var _isolate_helper;
   class _IsolateContext extends core.Object {
     _IsolateContext() {
       this.id = (() => {
-        let o$ = exports._globalState, x$ = o$.nextIsolateId;
-        o$.nextIsolateId = dart.notNull(x$) + 1;
-        return x$;
+        let o = exports._globalState, x = o.nextIsolateId;
+        o.nextIsolateId = dart.notNull(x) + 1;
+        return x;
       })();
       this.ports = new (core.Map$(core.int, RawReceivePortImpl))();
       this.weakPorts = new (core.Set$(core.int))();
@@ -1098,9 +1098,9 @@ var _isolate_helper;
         };
       }(_foreign_helper.DART_CLOSURE_TO_JS(IsolateNatives[_processWorkerMessage]), worker);
       worker.onmessage = processWorkerMessageTrampoline;
-      let o$ = exports._globalState;
-      let workerId = o$.nextManagerId;
-      o$.nextManagerId = dart.notNull(workerId) + 1;
+      let o = exports._globalState;
+      let workerId = o.nextManagerId;
+      o.nextManagerId = dart.notNull(workerId) + 1;
       IsolateNatives.workerIds.set(worker, workerId);
       exports._globalState.managers.set(workerId, worker);
       worker.postMessage(_serializeMessage(dart.map({command: 'start', id: workerId, replyTo: _serializeMessage(replyPort), args: args, msg: _serializeMessage(message), isSpawnUri: isSpawnUri, startPaused: startPaused, functionName: functionName})));
@@ -1129,8 +1129,8 @@ var _isolate_helper;
   });
   let _checkReplyTo = Symbol('_checkReplyTo');
   class _BaseSendPort extends core.Object {
-    _BaseSendPort(isolateId$) {
-      this[_isolateId] = isolateId$;
+    _BaseSendPort(isolateId) {
+      this[_isolateId] = isolateId;
     }
     [_checkReplyTo](replyTo) {
       if (dart.notNull(replyTo != null) && !dart.is(replyTo, _NativeJsSendPort) && !dart.is(replyTo, _WorkerSendPort)) {
@@ -1142,8 +1142,8 @@ var _isolate_helper;
   let _isClosed = Symbol('_isClosed');
   let _add = Symbol('_add');
   class _NativeJsSendPort extends _BaseSendPort {
-    _NativeJsSendPort(receivePort$, isolateId) {
-      this[_receivePort] = receivePort$;
+    _NativeJsSendPort(receivePort, isolateId) {
+      this[_receivePort] = receivePort;
       super._BaseSendPort(isolateId);
     }
     send(message) {
@@ -1172,9 +1172,9 @@ var _isolate_helper;
   }
   _NativeJsSendPort[dart.implements] = () => [isolate.SendPort];
   class _WorkerSendPort extends _BaseSendPort {
-    _WorkerSendPort(workerId$, isolateId, receivePortId$) {
-      this[_workerId] = workerId$;
-      this[_receivePortId] = receivePortId$;
+    _WorkerSendPort(workerId, isolateId, receivePortId) {
+      this[_workerId] = workerId;
+      this[_receivePortId] = receivePortId;
       super._BaseSendPort(isolateId);
     }
     send(message) {
@@ -1202,9 +1202,9 @@ var _isolate_helper;
     RawReceivePortImpl(handler) {
       this[_handler] = handler;
       this[_id] = (() => {
-        let x$ = RawReceivePortImpl[_nextFreeId];
-        RawReceivePortImpl[_nextFreeId] = dart.notNull(x$) + 1;
-        return x$;
+        let x = RawReceivePortImpl[_nextFreeId];
+        RawReceivePortImpl[_nextFreeId] = dart.notNull(x) + 1;
+        return x;
       })();
       this[_isClosed] = false;
       exports._globalState.currentContext.register(this[_id], this);
@@ -1212,9 +1212,9 @@ var _isolate_helper;
     weak(handler) {
       this[_handler] = handler;
       this[_id] = (() => {
-        let x$ = RawReceivePortImpl[_nextFreeId];
-        RawReceivePortImpl[_nextFreeId] = dart.notNull(x$) + 1;
-        return x$;
+        let x = RawReceivePortImpl[_nextFreeId];
+        RawReceivePortImpl[_nextFreeId] = dart.notNull(x) + 1;
+        return x;
       })();
       this[_isClosed] = false;
       exports._globalState.currentContext.registerWeak(this[_id], this);

--- a/lib/runtime/dart/_js_helper.js
+++ b/lib/runtime/dart/_js_helper.js
@@ -23,11 +23,11 @@ var _js_helper;
       this.name = name;
     }
   }
-  let _$ = Symbol('_');
+  let _ = Symbol('_');
   let _throwUnmodifiable = Symbol('_throwUnmodifiable');
   let ConstantMap$ = dart.generic(function(K, V) {
     class ConstantMap extends core.Object {
-      [_$]() {
+      [_]() {
       }
       get isEmpty() {
         return this.length == 0;
@@ -58,7 +58,7 @@ var _js_helper;
       }
     }
     ConstantMap[dart.implements] = () => [core.Map$(K, V)];
-    dart.defineNamedConstructor(ConstantMap, _$);
+    dart.defineNamedConstructor(ConstantMap, _);
     return ConstantMap;
   });
   let ConstantMap = ConstantMap$();
@@ -67,11 +67,11 @@ var _js_helper;
   let _fetch = Symbol('_fetch');
   let ConstantStringMap$ = dart.generic(function(K, V) {
     class ConstantStringMap extends ConstantMap$(K, V) {
-      [_$](length, jsObject$, keys$) {
+      [_](length, jsObject, keys) {
         this.length = length;
-        this[_jsObject] = jsObject$;
-        this[_keys] = keys$;
-        super[_$]();
+        this[_jsObject] = jsObject;
+        this[_keys] = keys;
+        super[_]();
       }
       containsValue(needle) {
         return this.values[core.$any](value => dart.equals(value, needle));
@@ -106,16 +106,16 @@ var _js_helper;
       }
     }
     ConstantStringMap[dart.implements] = () => [_internal.EfficientLength];
-    dart.defineNamedConstructor(ConstantStringMap, _$);
+    dart.defineNamedConstructor(ConstantStringMap, _);
     return ConstantStringMap;
   });
   let ConstantStringMap = ConstantStringMap$();
   let _protoValue = Symbol('_protoValue');
   let ConstantProtoMap$ = dart.generic(function(K, V) {
     class ConstantProtoMap extends ConstantStringMap$(K, V) {
-      [_$](length, jsObject, keys, protoValue) {
+      [_](length, jsObject, keys, protoValue) {
         this[_protoValue] = protoValue;
-        super[_$](dart.as(length, core.int), jsObject, dart.as(keys, core.List$(K)));
+        super[_](dart.as(length, core.int), jsObject, dart.as(keys, core.List$(K)));
       }
       containsKey(key) {
         if (!(typeof key == 'string'))
@@ -128,15 +128,15 @@ var _js_helper;
         return dart.equals('__proto__', key) ? this[_protoValue] : jsPropertyAccess(this[_jsObject], dart.as(key, core.String));
       }
     }
-    dart.defineNamedConstructor(ConstantProtoMap, _$);
+    dart.defineNamedConstructor(ConstantProtoMap, _);
     return ConstantProtoMap;
   });
   let ConstantProtoMap = ConstantProtoMap$();
   let _map = Symbol('_map');
   let _ConstantMapKeyIterable$ = dart.generic(function(K) {
     class _ConstantMapKeyIterable extends collection.IterableBase$(K) {
-      _ConstantMapKeyIterable(map$) {
-        this[_map] = map$;
+      _ConstantMapKeyIterable(map) {
+        this[_map] = map;
         super.IterableBase();
       }
       get [core.$iterator]() {
@@ -155,7 +155,7 @@ var _js_helper;
     class GeneralConstantMap extends ConstantMap$(K, V) {
       GeneralConstantMap(jsData) {
         this[_jsData] = jsData;
-        super[_$]();
+        super[_]();
       }
       [_getMap]() {
         if (!this.$map) {
@@ -581,9 +581,9 @@ var _js_helper;
   JSSyntaxRegExp[dart.implements] = () => [core.RegExp];
   let _match = Symbol('_match');
   class _MatchImplementation extends core.Object {
-    _MatchImplementation(pattern, match$) {
+    _MatchImplementation(pattern, match) {
       this.pattern = pattern;
-      this[_match] = match$;
+      this[_match] = match;
       dart.assert(typeof this[_match].input == 'string');
       dart.assert(typeof this[_match].index == 'number');
     }
@@ -618,10 +618,10 @@ var _js_helper;
   let _string = Symbol('_string');
   let _start = Symbol('_start');
   class _AllMatchesIterable extends collection.IterableBase$(core.Match) {
-    _AllMatchesIterable(re$, string$, start$) {
-      this[_re] = re$;
-      this[_string] = string$;
-      this[_start] = start$;
+    _AllMatchesIterable(re, string, start) {
+      this[_re] = re;
+      this[_string] = string;
+      this[_start] = start;
       super.IterableBase();
     }
     get [core.$iterator]() {
@@ -632,10 +632,10 @@ var _js_helper;
   let _nextIndex = Symbol('_nextIndex');
   let _current = Symbol('_current');
   class _AllMatchesIterator extends core.Object {
-    _AllMatchesIterator(regExp$, string$, nextIndex$) {
-      this[_regExp] = regExp$;
-      this[_string] = string$;
-      this[_nextIndex] = nextIndex$;
+    _AllMatchesIterator(regExp, string, nextIndex) {
+      this[_regExp] = regExp;
+      this[_string] = string;
+      this[_nextIndex] = nextIndex;
       this[_current] = null;
     }
     get current() {
@@ -877,8 +877,8 @@ var _js_helper;
   let _typeName = Symbol('_typeName');
   let _unmangledName = Symbol('_unmangledName');
   class TypeImpl extends core.Object {
-    TypeImpl(typeName$) {
-      this[_typeName] = typeName$;
+    TypeImpl(typeName) {
+      this[_typeName] = typeName;
       this[_unmangledName] = null;
     }
     toString() {
@@ -1402,10 +1402,10 @@ var _js_helper;
   let _namedIndices = Symbol('_namedIndices');
   let _getCachedInvocation = Symbol('_getCachedInvocation');
   class JSInvocationMirror extends core.Object {
-    JSInvocationMirror(memberName$, internalName$, kind$, arguments$, namedArgumentNames) {
-      this[_memberName] = memberName$;
-      this[_internalName] = internalName$;
-      this[_kind] = kind$;
+    JSInvocationMirror(memberName, internalName, kind, arguments$, namedArgumentNames) {
+      this[_memberName] = memberName;
+      this[_internalName] = internalName;
+      this[_kind] = kind;
       this[_arguments] = arguments$;
       this[_namedArgumentNames] = namedArgumentNames;
       this[_namedIndices] = null;
@@ -1539,9 +1539,9 @@ var _js_helper;
         if (!dart.is(arguments$, _interceptors.JSArray))
           arguments$ = new core.List.from(arguments$);
       } else {
-        let _$ = new core.List.from([victim]);
-        _$[core.$addAll](arguments$);
-        arguments$ = _$;
+        let _ = new core.List.from([victim]);
+        _[core.$addAll](arguments$);
+        arguments$ = _;
         if (this.cachedInterceptor != null)
           receiver = this.cachedInterceptor;
       }
@@ -1571,9 +1571,9 @@ var _js_helper;
           providedArgumentCount = arguments$[core.$length];
         }
       } else {
-        let _$ = new core.List.from([victim]);
-        _$[core.$addAll](arguments$);
-        arguments$ = _$;
+        let _ = new core.List.from([victim]);
+        _[core.$addAll](arguments$);
+        arguments$ = _;
         if (this.cachedInterceptor != null)
           receiver = this.cachedInterceptor;
         providedArgumentCount = dart.notNull(arguments$[core.$length]) - 1;
@@ -1681,14 +1681,14 @@ var _js_helper;
         }
         let index = 0;
         (() => {
-          let _$ = positions.keys[core.$toList]();
-          _$[core.$sort]();
-          return _$;
+          let _ = positions.keys[core.$toList]();
+          _[core.$sort]();
+          return _;
         })()[core.$forEach]((name => {
           this.cachedSortedIndices[core.$set]((() => {
-            let x$ = index;
-            index = dart.notNull(x$) + 1;
-            return x$;
+            let x = index;
+            index = dart.notNull(x) + 1;
+            return x;
           })(), positions.get(name));
         }).bind(this));
       }
@@ -2229,13 +2229,13 @@ var _js_helper;
   let _receiver = Symbol('_receiver');
   let _pattern = Symbol('_pattern');
   class TypeErrorDecoder extends core.Object {
-    TypeErrorDecoder(arguments$, argumentsExpr$, expr$, method$, receiver$, pattern$) {
+    TypeErrorDecoder(arguments$, argumentsExpr, expr, method, receiver, pattern) {
       this[_arguments] = arguments$;
-      this[_argumentsExpr] = argumentsExpr$;
-      this[_expr] = expr$;
-      this[_method] = method$;
-      this[_receiver] = receiver$;
-      this[_pattern] = pattern$;
+      this[_argumentsExpr] = argumentsExpr;
+      this[_expr] = expr;
+      this[_method] = method;
+      this[_receiver] = receiver;
+      this[_pattern] = pattern;
     }
     matchTypeError(message) {
       let match = new RegExp(this[_pattern]).exec(message);
@@ -2392,8 +2392,8 @@ var _js_helper;
   });
   let _message = Symbol('_message');
   class NullError extends core.Error {
-    NullError(message$, match) {
-      this[_message] = message$;
+    NullError(message, match) {
+      this[_message] = message;
       this[_method] = dart.as(match == null ? null : match.method, core.String);
       super.Error();
     }
@@ -2405,8 +2405,8 @@ var _js_helper;
   }
   NullError[dart.implements] = () => [core.NoSuchMethodError];
   class JsNoSuchMethodError extends core.Error {
-    JsNoSuchMethodError(message$, match) {
-      this[_message] = message$;
+    JsNoSuchMethodError(message, match) {
+      this[_message] = message;
       this[_method] = dart.as(match == null ? null : match.method, core.String);
       this[_receiver] = dart.as(match == null ? null : match.receiver, core.String);
       super.Error();
@@ -2422,8 +2422,8 @@ var _js_helper;
   }
   JsNoSuchMethodError[dart.implements] = () => [core.NoSuchMethodError];
   class UnknownJsTypeError extends core.Error {
-    UnknownJsTypeError(message$) {
-      this[_message] = message$;
+    UnknownJsTypeError(message) {
+      this[_message] = message;
       super.Error();
     }
     toString() {
@@ -2512,8 +2512,8 @@ var _js_helper;
   let _exception = Symbol('_exception');
   let _trace = Symbol('_trace');
   class _StackTrace extends core.Object {
-    _StackTrace(exception$) {
-      this[_exception] = exception$;
+    _StackTrace(exception) {
+      this[_exception] = exception;
       this[_trace] = null;
     }
     toString() {
@@ -2541,14 +2541,14 @@ var _js_helper;
     let length = getLength(keyValuePairs);
     while (dart.notNull(index) < dart.notNull(length)) {
       let key = getIndex(keyValuePairs, (() => {
-        let x$ = index;
-        index = dart.notNull(x$) + 1;
-        return x$;
+        let x = index;
+        index = dart.notNull(x) + 1;
+        return x;
       })());
       let value = getIndex(keyValuePairs, (() => {
-        let x$ = index;
-        index = dart.notNull(x$) + 1;
-        return x$;
+        let x = index;
+        index = dart.notNull(x) + 1;
+        return x;
       })());
       result.set(key, value);
     }
@@ -2606,9 +2606,9 @@ var _js_helper;
       } : Closure.isCsp ? function(a, b, c, d) {
         this.$initialize(a, b, c, d);
       } : new Function("a", "b", "c", "d", "this.$initialize(a,b,c,d);" + (() => {
-        let x$ = Closure.functionCounter;
-        Closure.functionCounter = dart.notNull(x$) + 1;
-        return x$;
+        let x = Closure.functionCounter;
+        Closure.functionCounter = dart.notNull(x) + 1;
+        return x;
       })());
       prototype.constructor = constructor;
       constructor.prototype = prototype;
@@ -2731,17 +2731,17 @@ var _js_helper;
       }
       if (arity == 0) {
         return new Function('return function(){' + `return this.${BoundClosure.selfFieldName()}.${stubName}();` + `${(() => {
-          let x$ = Closure.functionCounter;
-          Closure.functionCounter = dart.notNull(x$) + 1;
-          return x$;
+          let x = Closure.functionCounter;
+          Closure.functionCounter = dart.notNull(x) + 1;
+          return x;
         })()}` + '}')();
       }
       dart.assert(1 <= dart.notNull(arity) && dart.notNull(arity) < 27);
       let arguments$ = "abcdefghijklmnopqrstuvwxyz".split("").splice(0, arity).join(",");
       return new Function(`return function(${arguments$}){` + `return this.${BoundClosure.selfFieldName()}.${stubName}(${arguments$});` + `${(() => {
-        let x$ = Closure.functionCounter;
-        Closure.functionCounter = dart.notNull(x$) + 1;
-        return x$;
+        let x = Closure.functionCounter;
+        Closure.functionCounter = dart.notNull(x) + 1;
+        return x;
       })()}` + '}')();
     }
     static cspForwardInterceptedCall(arity, isSuperCall, name, func) {
@@ -2827,17 +2827,17 @@ var _js_helper;
       }
       if (arity == 1) {
         return new Function('return function(){' + `return this.${selfField}.${stubName}(this.${receiverField});` + `${(() => {
-          let x$ = Closure.functionCounter;
-          Closure.functionCounter = dart.notNull(x$) + 1;
-          return x$;
+          let x = Closure.functionCounter;
+          Closure.functionCounter = dart.notNull(x) + 1;
+          return x;
         })()}` + '}')();
       }
       dart.assert(1 < dart.notNull(arity) && dart.notNull(arity) < 28);
       let arguments$ = "abcdefghijklmnopqrstuvwxyz".split("").splice(0, dart.notNull(arity) - 1).join(",");
       return new Function(`return function(${arguments$}){` + `return this.${selfField}.${stubName}(this.${receiverField}, ${arguments$});` + `${(() => {
-        let x$ = Closure.functionCounter;
-        Closure.functionCounter = dart.notNull(x$) + 1;
-        return x$;
+        let x = Closure.functionCounter;
+        Closure.functionCounter = dart.notNull(x) + 1;
+        return x;
       })()}` + '}')();
     }
     toString() {
@@ -2861,11 +2861,11 @@ var _js_helper;
   let _target = Symbol('_target');
   let _name = Symbol('_name');
   class BoundClosure extends TearOffClosure {
-    BoundClosure(self$, target$, receiver$, name$) {
-      this[_self] = self$;
-      this[_target] = target$;
-      this[_receiver] = receiver$;
-      this[_name] = name$;
+    BoundClosure(self, target, receiver, name) {
+      this[_self] = self;
+      this[_target] = target;
+      this[_receiver] = receiver;
+      this[_name] = name;
       super.TearOffClosure();
     }
     ['=='](other) {
@@ -3663,8 +3663,8 @@ var _js_helper;
     }
   }
   class UnimplementedNoSuchMethodError extends core.Error {
-    UnimplementedNoSuchMethodError(message$) {
-      this[_message] = message$;
+    UnimplementedNoSuchMethodError(message) {
+      this[_message] = message;
       super.Error();
     }
     toString() {
@@ -3798,8 +3798,8 @@ var _js_helper;
     }));
   }
   class MainError extends core.Error {
-    MainError(message$) {
-      this[_message] = message$;
+    MainError(message) {
+      this[_message] = message;
       super.Error();
     }
     toString() {

--- a/lib/runtime/dart/_native_typed_data.js
+++ b/lib/runtime/dart/_native_typed_data.js
@@ -129,8 +129,8 @@ var _native_typed_data;
     NativeFloat32x4List(length) {
       this[_storage] = new NativeFloat32List(dart.notNull(length) * 4);
     }
-    [_externalStorage](storage$) {
-      this[_storage] = storage$;
+    [_externalStorage](storage) {
+      this[_storage] = storage;
     }
     [_slowFromList](list) {
       this[_storage] = new NativeFloat32List(dart.notNull(list[core.$length]) * 4);
@@ -313,8 +313,8 @@ var _native_typed_data;
     NativeFloat64x2List(length) {
       this[_storage] = new NativeFloat64List(dart.notNull(length) * 2);
     }
-    [_externalStorage](storage$) {
-      this[_storage] = storage$;
+    [_externalStorage](storage) {
+      this[_storage] = storage;
     }
     [_slowFromList](list) {
       this[_storage] = new NativeFloat64List(dart.notNull(list[core.$length]) * 2);
@@ -1216,10 +1216,10 @@ var _native_typed_data;
       return new NativeFloat32x4[_truncated](_x, _y, _z, _w);
     }
     sqrt() {
-      let _x = Math.sqrt(this.x);
-      let _y = Math.sqrt(this.y);
-      let _z = Math.sqrt(this.z);
-      let _w = Math.sqrt(this.w);
+      let _x = math.sqrt(this.x);
+      let _y = math.sqrt(this.y);
+      let _z = math.sqrt(this.z);
+      let _w = math.sqrt(this.w);
       return new NativeFloat32x4[_doubles](_x, _y, _z, _w);
     }
     reciprocal() {
@@ -1230,10 +1230,10 @@ var _native_typed_data;
       return new NativeFloat32x4[_doubles](_x, _y, _z, _w);
     }
     reciprocalSqrt() {
-      let _x = Math.sqrt(1.0 / dart.notNull(this.x));
-      let _y = Math.sqrt(1.0 / dart.notNull(this.y));
-      let _z = Math.sqrt(1.0 / dart.notNull(this.z));
-      let _w = Math.sqrt(1.0 / dart.notNull(this.w));
+      let _x = math.sqrt(1.0 / dart.notNull(this.x));
+      let _y = math.sqrt(1.0 / dart.notNull(this.y));
+      let _z = math.sqrt(1.0 / dart.notNull(this.z));
+      let _w = math.sqrt(1.0 / dart.notNull(this.w));
       return new NativeFloat32x4[_doubles](_x, _y, _z, _w);
     }
   }
@@ -1520,7 +1520,7 @@ var _native_typed_data;
       return new NativeFloat64x2[_doubles](dart.notNull(this.x) > dart.notNull(other.x) ? this.x : other.x, dart.notNull(this.y) > dart.notNull(other.y) ? this.y : other.y);
     }
     sqrt() {
-      return new NativeFloat64x2[_doubles](Math.sqrt(this.x), Math.sqrt(this.y));
+      return new NativeFloat64x2[_doubles](math.sqrt(this.x), math.sqrt(this.y));
     }
   }
   NativeFloat64x2[dart.implements] = () => [typed_data.Float64x2];

--- a/lib/runtime/dart/async.js
+++ b/lib/runtime/dart/async.js
@@ -793,8 +793,8 @@ var async;
   let _StreamImpl = _StreamImpl$();
   let _ControllerStream$ = dart.generic(function(T) {
     class _ControllerStream extends _StreamImpl$(T) {
-      _ControllerStream(controller$) {
-        this[_controller] = controller$;
+      _ControllerStream(controller) {
+        this[_controller] = controller;
         super._StreamImpl();
       }
       [_createSubscription](onData, onError, onDone, cancelOnError) {
@@ -1198,8 +1198,8 @@ var async;
   let _BufferingStreamSubscription = _BufferingStreamSubscription$();
   let _ControllerSubscription$ = dart.generic(function(T) {
     class _ControllerSubscription extends _BufferingStreamSubscription$(T) {
-      _ControllerSubscription(controller$, onData, onError, onDone, cancelOnError) {
-        this[_controller] = controller$;
+      _ControllerSubscription(controller, onData, onError, onDone, cancelOnError) {
+        this[_controller] = controller;
         super._BufferingStreamSubscription(onData, onError, onDone, cancelOnError);
       }
       [_onCancel]() {
@@ -1271,9 +1271,9 @@ var async;
   let _asyncComplete = Symbol('_asyncComplete');
   let _BroadcastStreamController$ = dart.generic(function(T) {
     class _BroadcastStreamController extends core.Object {
-      _BroadcastStreamController(onListen$, onCancel$) {
-        this[_onListen] = onListen$;
-        this[_onCancel] = onCancel$;
+      _BroadcastStreamController(onListen, onCancel) {
+        this[_onListen] = onListen;
+        this[_onCancel] = onCancel;
         this[_state] = _BroadcastStreamController[_STATE_INITIAL];
         this[_next] = null;
         this[_previous] = null;
@@ -1663,8 +1663,8 @@ var async;
   }
   let _s = Symbol('_s');
   class DeferredLoadException extends core.Object {
-    DeferredLoadException(s$) {
-      this[_s] = s$;
+    DeferredLoadException(s) {
+      this[_s] = s;
     }
     toString() {
       return `DeferredLoadException: '${this[_s]}'`;
@@ -2632,8 +2632,8 @@ var async;
   let _stream = Symbol('_stream');
   let StreamView$ = dart.generic(function(T) {
     class StreamView extends Stream$(T) {
-      StreamView(stream$) {
-        this[_stream] = stream$;
+      StreamView(stream) {
+        this[_stream] = stream;
         super.Stream();
       }
       get isBroadcast() {
@@ -2689,8 +2689,8 @@ var async;
   let StreamIterator = StreamIterator$();
   let _ControllerEventSinkWrapper$ = dart.generic(function(T) {
     class _ControllerEventSinkWrapper extends core.Object {
-      _ControllerEventSinkWrapper(sink$) {
-        this[_sink] = sink$;
+      _ControllerEventSinkWrapper(sink) {
+        this[_sink] = sink;
       }
       add(data) {
         this[_sink].add(data);
@@ -3012,11 +3012,11 @@ var async;
   let _AsyncStreamControllerDispatch = _AsyncStreamControllerDispatch$();
   let _AsyncStreamController$ = dart.generic(function(T) {
     class _AsyncStreamController extends dart.mixin(_StreamController$(T), _AsyncStreamControllerDispatch$(T)) {
-      _AsyncStreamController(onListen$, onPause$, onResume$, onCancel$) {
-        this[_onListen] = onListen$;
-        this[_onPause] = onPause$;
-        this[_onResume] = onResume$;
-        this[_onCancel] = onCancel$;
+      _AsyncStreamController(onListen, onPause, onResume, onCancel) {
+        this[_onListen] = onListen;
+        this[_onPause] = onPause;
+        this[_onResume] = onResume;
+        this[_onCancel] = onCancel;
         super._StreamController();
       }
     }
@@ -3025,11 +3025,11 @@ var async;
   let _AsyncStreamController = _AsyncStreamController$();
   let _SyncStreamController$ = dart.generic(function(T) {
     class _SyncStreamController extends dart.mixin(_StreamController$(T), _SyncStreamControllerDispatch$(T)) {
-      _SyncStreamController(onListen$, onPause$, onResume$, onCancel$) {
-        this[_onListen] = onListen$;
-        this[_onPause] = onPause$;
-        this[_onResume] = onResume$;
-        this[_onCancel] = onCancel$;
+      _SyncStreamController(onListen, onPause, onResume, onCancel) {
+        this[_onListen] = onListen;
+        this[_onPause] = onPause;
+        this[_onResume] = onResume;
+        this[_onCancel] = onCancel;
         super._StreamController();
       }
     }
@@ -3071,8 +3071,8 @@ var async;
   let _target = Symbol('_target');
   let _StreamSinkWrapper$ = dart.generic(function(T) {
     class _StreamSinkWrapper extends core.Object {
-      _StreamSinkWrapper(target$) {
-        this[_target] = target$;
+      _StreamSinkWrapper(target) {
+        this[_target] = target;
       }
       add(data) {
         this[_target].add(data);
@@ -3159,8 +3159,8 @@ var async;
   let _isUsed = Symbol('_isUsed');
   let _GeneratedStreamImpl$ = dart.generic(function(T) {
     class _GeneratedStreamImpl extends _StreamImpl$(T) {
-      _GeneratedStreamImpl(pending$) {
-        this[_pending] = pending$;
+      _GeneratedStreamImpl(pending) {
+        this[_pending] = pending;
         this[_isUsed] = false;
         super._StreamImpl();
       }
@@ -3168,9 +3168,9 @@ var async;
         if (this[_isUsed])
           throw new core.StateError("Stream has already been listened to.");
         this[_isUsed] = true;
-        let _$ = new _BufferingStreamSubscription(onData, onError, onDone, cancelOnError);
-        _$[_setPendingEvents](this[_pending]());
-        return _$;
+        let _ = new _BufferingStreamSubscription(onData, onError, onDone, cancelOnError);
+        _[_setPendingEvents](this[_pending]());
+        return _;
       }
     }
     return _GeneratedStreamImpl;
@@ -3375,8 +3375,8 @@ var async;
   let _PAUSED = Symbol('_PAUSED');
   let _DoneStreamSubscription$ = dart.generic(function(T) {
     class _DoneStreamSubscription extends core.Object {
-      _DoneStreamSubscription(onDone$) {
-        this[_onDone] = onDone$;
+      _DoneStreamSubscription(onDone) {
+        this[_onDone] = onDone;
         this[_zone] = Zone.current;
         this[_state] = 0;
         this[_schedule]();
@@ -3453,8 +3453,8 @@ var async;
   let _isSubscriptionPaused = Symbol('_isSubscriptionPaused');
   let _AsBroadcastStream$ = dart.generic(function(T) {
     class _AsBroadcastStream extends Stream$(T) {
-      _AsBroadcastStream(source$, onListenHandler, onCancelHandler) {
-        this[_source] = source$;
+      _AsBroadcastStream(source, onListenHandler, onCancelHandler) {
+        this[_source] = source;
         this[_onListenHandler] = dart.as(Zone.current.registerUnaryCallback(onListenHandler), _broadcastCallback);
         this[_onCancelHandler] = dart.as(Zone.current.registerUnaryCallback(onCancelHandler), _broadcastCallback);
         this[_zone] = Zone.current;
@@ -3525,8 +3525,8 @@ var async;
   let _AsBroadcastStream = _AsBroadcastStream$();
   let _BroadcastSubscriptionWrapper$ = dart.generic(function(T) {
     class _BroadcastSubscriptionWrapper extends core.Object {
-      _BroadcastSubscriptionWrapper(stream$) {
-        this[_stream] = stream$;
+      _BroadcastSubscriptionWrapper(stream) {
+        this[_stream] = stream;
       }
       onData(handleData) {
         throw new core.UnsupportedError("Cannot change handlers of asBroadcastStream source subscription.");
@@ -3740,8 +3740,8 @@ var async;
   let _handleDone = Symbol('_handleDone');
   let _ForwardingStream$ = dart.generic(function(S, T) {
     class _ForwardingStream extends Stream$(T) {
-      _ForwardingStream(source$) {
-        this[_source] = source$;
+      _ForwardingStream(source) {
+        this[_source] = source;
         super.Stream();
       }
       get isBroadcast() {
@@ -3773,8 +3773,8 @@ var async;
   let _ForwardingStream = _ForwardingStream$();
   let _ForwardingStreamSubscription$ = dart.generic(function(S, T) {
     class _ForwardingStreamSubscription extends _BufferingStreamSubscription$(T) {
-      _ForwardingStreamSubscription(stream$, onData, onError, onDone, cancelOnError) {
-        this[_stream] = stream$;
+      _ForwardingStreamSubscription(stream, onData, onError, onDone, cancelOnError) {
+        this[_stream] = stream;
         this[_subscription] = null;
         super._BufferingStreamSubscription(onData, onError, onDone, cancelOnError);
         this[_subscription] = this[_stream][_source].listen(this[_handleData], {onError: this[_handleError], onDone: this[_handleDone]});
@@ -4100,8 +4100,8 @@ var async;
   let _DistinctStream = _DistinctStream$();
   let _EventSinkWrapper$ = dart.generic(function(T) {
     class _EventSinkWrapper extends core.Object {
-      _EventSinkWrapper(sink$) {
-        this[_sink] = sink$;
+      _EventSinkWrapper(sink) {
+        this[_sink] = sink;
       }
       add(data) {
         this[_sink][_add](data);
@@ -4230,8 +4230,8 @@ var async;
       get isBroadcast() {
         return this[_stream].isBroadcast;
       }
-      _BoundSinkStream(stream$, sinkMapper) {
-        this[_stream] = stream$;
+      _BoundSinkStream(stream, sinkMapper) {
+        this[_stream] = stream;
         this[_sinkMapper] = sinkMapper;
         super.Stream();
       }
@@ -4264,11 +4264,11 @@ var async;
   let _TransformDoneHandler = _TransformDoneHandler$();
   let _HandlerEventSink$ = dart.generic(function(S, T) {
     class _HandlerEventSink extends core.Object {
-      _HandlerEventSink(handleData$, handleError$, handleDone$, sink$) {
-        this[_handleData] = handleData$;
-        this[_handleError] = handleError$;
-        this[_handleDone] = handleDone$;
-        this[_sink] = sink$;
+      _HandlerEventSink(handleData, handleError, handleDone, sink) {
+        this[_handleData] = handleData;
+        this[_handleError] = handleError;
+        this[_handleDone] = handleDone;
+        this[_sink] = sink;
       }
       add(data) {
         return this[_handleData](data, this[_sink]);
@@ -4329,8 +4329,8 @@ var async;
   let _transformer = Symbol('_transformer');
   let _StreamSubscriptionTransformer$ = dart.generic(function(S, T) {
     class _StreamSubscriptionTransformer extends core.Object {
-      _StreamSubscriptionTransformer(transformer$) {
-        this[_transformer] = transformer$;
+      _StreamSubscriptionTransformer(transformer) {
+        this[_transformer] = transformer;
       }
       bind(stream) {
         return new (_BoundSubscriptionStream$(S, T))(stream, this[_transformer]);
@@ -4342,9 +4342,9 @@ var async;
   let _StreamSubscriptionTransformer = _StreamSubscriptionTransformer$();
   let _BoundSubscriptionStream$ = dart.generic(function(S, T) {
     class _BoundSubscriptionStream extends Stream$(T) {
-      _BoundSubscriptionStream(stream$, transformer$) {
-        this[_stream] = stream$;
-        this[_transformer] = transformer$;
+      _BoundSubscriptionStream(stream, transformer) {
+        this[_stream] = stream;
+        this[_transformer] = transformer;
         super.Stream();
       }
       listen(onData, opts) {
@@ -4469,9 +4469,9 @@ var async;
   }
   _ZoneSpecification[dart.implements] = () => [ZoneSpecification];
   class ZoneDelegate extends core.Object {}
-  let _$ = Symbol('_');
+  let _ = Symbol('_');
   class Zone extends core.Object {
-    [_$]() {
+    [_]() {
     }
     static get current() {
       return Zone[_current];
@@ -4488,7 +4488,7 @@ var async;
       Zone[_current] = previous;
     }
   }
-  dart.defineNamedConstructor(Zone, _$);
+  dart.defineNamedConstructor(Zone, _);
   Zone.ROOT = _ROOT_ZONE;
   Zone._current = _ROOT_ZONE;
   let _delegate = Symbol('_delegate');

--- a/lib/runtime/dart/collection.js
+++ b/lib/runtime/dart/collection.js
@@ -180,9 +180,9 @@ var collection;
         let i = 0;
         for (let element of this)
           result[core.$set]((() => {
-            let x$ = i;
-            i = dart.notNull(x$) + 1;
-            return x$;
+            let x = i;
+            i = dart.notNull(x) + 1;
+            return x;
           })(), element);
         return result;
       }
@@ -975,8 +975,8 @@ var collection;
   let _NO_NEXT = Symbol('_NO_NEXT');
   let HasNextIterator$ = dart.generic(function(E) {
     class HasNextIterator extends core.Object {
-      HasNextIterator(iterator$) {
-        this[_iterator] = iterator$;
+      HasNextIterator(iterator) {
+        this[_iterator] = iterator;
         this[_state] = HasNextIterator[_NOT_MOVED_YET];
       }
       get hasNext() {
@@ -1506,17 +1506,17 @@ var collection;
       }
       [core.$add](element) {
         this[core.$set]((() => {
-          let o$ = this, x$ = o$[core.$length];
-          o$[core.$length] = dart.notNull(x$) + 1;
-          return x$;
+          let o = this, x = o[core.$length];
+          o[core.$length] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), element);
       }
       [core.$addAll](iterable) {
         for (let element of iterable) {
           this[core.$set]((() => {
-            let o$ = this, x$ = o$[core.$length];
-            o$[core.$length] = dart.notNull(x$) + 1;
-            return x$;
+            let o = this, x = o[core.$length];
+            o[core.$length] = dart.notNull(x) + 1;
+            return x;
           }).bind(this)(), element);
         }
       }
@@ -1524,8 +1524,8 @@ var collection;
         for (let i = 0; dart.notNull(i) < dart.notNull(this[core.$length]); i = dart.notNull(i) + 1) {
           if (dart.equals(this[core.$get](i), element)) {
             this[core.$setRange](i, dart.notNull(this[core.$length]) - 1, this, dart.notNull(i) + 1);
-            let o$ = this;
-            o$[core.$length] = dart.notNull(o$[core.$length]) - 1;
+            let o = this;
+            o[core.$length] = dart.notNull(o[core.$length]) - 1;
             return true;
           }
         }
@@ -1614,8 +1614,8 @@ var collection;
         core.RangeError.checkValidRange(start, end, this[core.$length]);
         let length = dart.notNull(end) - dart.notNull(start);
         this[core.$setRange](start, dart.notNull(this[core.$length]) - dart.notNull(length), this, end);
-        let o$ = this;
-        o$[core.$length] = dart.notNull(o$[core.$length]) - dart.notNull(length);
+        let o = this;
+        o[core.$length] = dart.notNull(o[core.$length]) - dart.notNull(length);
       }
       [core.$fillRange](start, end, fill) {
         if (fill === void 0)
@@ -1724,8 +1724,8 @@ var collection;
         }
         if (!(typeof index == 'number'))
           throw new core.ArgumentError(index);
-        let o$ = this;
-        o$[core.$length] = dart.notNull(o$[core.$length]) + 1;
+        let o = this;
+        o[core.$length] = dart.notNull(o[core.$length]) + 1;
         this[core.$setRange](dart.notNull(index) + 1, this[core.$length], this, index);
         this[core.$set](index, element);
       }
@@ -1741,8 +1741,8 @@ var collection;
           iterable = iterable[core.$toList]();
         }
         let insertionLength = iterable[core.$length];
-        let o$ = this;
-        o$[core.$length] = dart.notNull(o$[core.$length]) + dart.notNull(insertionLength);
+        let o = this;
+        o[core.$length] = dart.notNull(o[core.$length]) + dart.notNull(insertionLength);
         this[core.$setRange](dart.notNull(index) + dart.notNull(insertionLength), this[core.$length], this, index);
         this[core.$setAll](index, iterable);
       }
@@ -1752,9 +1752,9 @@ var collection;
         } else {
           for (let element of iterable) {
             this[core.$set]((() => {
-              let x$ = index;
-              index = dart.notNull(x$) + 1;
-              return x$;
+              let x = index;
+              index = dart.notNull(x) + 1;
+              return x;
             })(), element);
           }
         }
@@ -1862,8 +1862,8 @@ var collection;
   let _map = Symbol('_map');
   let _MapBaseValueIterable$ = dart.generic(function(V) {
     class _MapBaseValueIterable extends IterableBase$(V) {
-      _MapBaseValueIterable(map$) {
-        this[_map] = map$;
+      _MapBaseValueIterable(map) {
+        this[_map] = map;
         super.IterableBase();
       }
       get [core.$length]() {
@@ -2820,7 +2820,7 @@ var collection;
   let _TypeTest = _TypeTest$();
   let _comparator = Symbol('_comparator');
   let _validKey = Symbol('_validKey');
-  let _internal$ = Symbol('_internal');
+  let _internal = Symbol('_internal');
   let SplayTreeMap$ = dart.generic(function(K, V) {
     class SplayTreeMap extends _SplayTree$(K) {
       SplayTreeMap(compare, isValidKey) {
@@ -2864,7 +2864,7 @@ var collection;
       [_compare](key1, key2) {
         return this[_comparator](key1, key2);
       }
-      [_internal$]() {
+      [_internal]() {
         this[_comparator] = null;
         this[_validKey] = null;
         super._SplayTree();
@@ -3025,7 +3025,7 @@ var collection;
     dart.defineNamedConstructor(SplayTreeMap, 'from');
     dart.defineNamedConstructor(SplayTreeMap, 'fromIterable');
     dart.defineNamedConstructor(SplayTreeMap, 'fromIterables');
-    dart.defineNamedConstructor(SplayTreeMap, _internal$);
+    dart.defineNamedConstructor(SplayTreeMap, _internal);
     return SplayTreeMap;
   });
   let SplayTreeMap = SplayTreeMap$();
@@ -3107,8 +3107,8 @@ var collection;
   let _copyNode = Symbol('_copyNode');
   let _SplayTreeKeyIterable$ = dart.generic(function(K) {
     class _SplayTreeKeyIterable extends IterableBase$(K) {
-      _SplayTreeKeyIterable(tree$) {
-        this[_tree] = tree$;
+      _SplayTreeKeyIterable(tree) {
+        this[_tree] = tree;
         super.IterableBase();
       }
       get [core.$length]() {
@@ -3134,8 +3134,8 @@ var collection;
   let _SplayTreeKeyIterable = _SplayTreeKeyIterable$();
   let _SplayTreeValueIterable$ = dart.generic(function(K, V) {
     class _SplayTreeValueIterable extends IterableBase$(V) {
-      _SplayTreeValueIterable(map$) {
-        this[_map] = map$;
+      _SplayTreeValueIterable(map) {
+        this[_map] = map;
         super.IterableBase();
       }
       get [core.$length]() {
@@ -3654,9 +3654,9 @@ var collection;
   let _hashCode = Symbol('_hashCode');
   let _CustomHashMap$ = dart.generic(function(K, V) {
     class _CustomHashMap extends _HashMap$(K, V) {
-      _CustomHashMap(equals$, hashCode$, validKey) {
-        this[_equals] = equals$;
-        this[_hashCode] = hashCode$;
+      _CustomHashMap(equals, hashCode, validKey) {
+        this[_equals] = equals;
+        this[_hashCode] = hashCode;
         this[_validKey] = dart.as(validKey != null ? validKey : v => dart.is(v, K), _Predicate);
         super._HashMap();
       }
@@ -3700,8 +3700,8 @@ var collection;
   let _CustomHashMap = _CustomHashMap$();
   let HashMapKeyIterable$ = dart.generic(function(E) {
     class HashMapKeyIterable extends IterableBase$(E) {
-      HashMapKeyIterable(map$) {
-        this[_map] = map$;
+      HashMapKeyIterable(map) {
+        this[_map] = map;
         super.IterableBase();
       }
       get [core.$length]() {
@@ -3733,9 +3733,9 @@ var collection;
   let _offset = Symbol('_offset');
   let HashMapKeyIterator$ = dart.generic(function(E) {
     class HashMapKeyIterator extends core.Object {
-      HashMapKeyIterator(map$, keys$) {
-        this[_map] = map$;
-        this[_keys] = keys$;
+      HashMapKeyIterator(map, keys) {
+        this[_map] = map;
+        this[_keys] = keys;
         this[_offset] = 0;
         this[_current] = null;
       }
@@ -4057,9 +4057,9 @@ var collection;
   let _LinkedIdentityHashMap = _LinkedIdentityHashMap$();
   let _LinkedCustomHashMap$ = dart.generic(function(K, V) {
     class _LinkedCustomHashMap extends _LinkedHashMap$(K, V) {
-      _LinkedCustomHashMap(equals$, hashCode$, validKey) {
-        this[_equals] = equals$;
-        this[_hashCode] = hashCode$;
+      _LinkedCustomHashMap(equals, hashCode, validKey) {
+        this[_equals] = equals;
+        this[_hashCode] = hashCode;
         this[_validKey] = dart.as(validKey != null ? validKey : v => dart.is(v, K), _Predicate);
         super._LinkedHashMap();
       }
@@ -4100,17 +4100,17 @@ var collection;
   });
   let _LinkedCustomHashMap = _LinkedCustomHashMap$();
   class LinkedHashMapCell extends core.Object {
-    LinkedHashMapCell(key$, value$) {
-      this[_key] = key$;
-      this[_value] = value$;
+    LinkedHashMapCell(key, value) {
+      this[_key] = key;
+      this[_value] = value;
       this[_next] = null;
       this[_previous] = null;
     }
   }
   let LinkedHashMapKeyIterable$ = dart.generic(function(E) {
     class LinkedHashMapKeyIterable extends IterableBase$(E) {
-      LinkedHashMapKeyIterable(map$) {
-        this[_map] = map$;
+      LinkedHashMapKeyIterable(map) {
+        this[_map] = map;
         super.IterableBase();
       }
       get [core.$length]() {
@@ -4144,9 +4144,9 @@ var collection;
   let _cell = Symbol('_cell');
   let LinkedHashMapKeyIterator$ = dart.generic(function(E) {
     class LinkedHashMapKeyIterator extends core.Object {
-      LinkedHashMapKeyIterator(map$, modifications$) {
-        this[_map] = map$;
-        this[_modifications] = modifications$;
+      LinkedHashMapKeyIterator(map, modifications) {
+        this[_map] = map;
+        this[_modifications] = modifications;
         this[_cell] = null;
         this[_current] = null;
         this[_cell] = dart.as(dart.dload(this[_map], _first), LinkedHashMapCell);
@@ -4480,9 +4480,9 @@ var collection;
   let _CustomHashSet = _CustomHashSet$();
   let HashSetIterator$ = dart.generic(function(E) {
     class HashSetIterator extends core.Object {
-      HashSetIterator(set$, elements$) {
-        this[_set] = set$;
-        this[_elements] = elements$;
+      HashSetIterator(set, elements) {
+        this[_set] = set;
+        this[_elements] = elements;
         this[_offset] = 0;
         this[_current] = null;
       }
@@ -4865,17 +4865,17 @@ var collection;
   });
   let _LinkedCustomHashSet = _LinkedCustomHashSet$();
   class LinkedHashSetCell extends core.Object {
-    LinkedHashSetCell(element$) {
-      this[_element] = element$;
+    LinkedHashSetCell(element) {
+      this[_element] = element;
       this[_next] = null;
       this[_previous] = null;
     }
   }
   let LinkedHashSetIterator$ = dart.generic(function(E) {
     class LinkedHashSetIterator extends core.Object {
-      LinkedHashSetIterator(set$, modifications$) {
-        this[_set] = set$;
-        this[_modifications] = modifications$;
+      LinkedHashSetIterator(set, modifications) {
+        this[_set] = set;
+        this[_modifications] = modifications;
         this[_cell] = null;
         this[_current] = null;
         this[_cell] = dart.as(dart.dload(this[_set], _first), LinkedHashSetCell);

--- a/lib/runtime/dart/convert.js
+++ b/lib/runtime/dart/convert.js
@@ -148,9 +148,9 @@ var convert;
   StringConversionSinkMixin[dart.implements] = () => [StringConversionSink];
   class StringConversionSinkBase extends StringConversionSinkMixin {}
   class _UnicodeSubsetEncoderSink extends StringConversionSinkBase {
-    _UnicodeSubsetEncoderSink(subsetMask, sink$) {
+    _UnicodeSubsetEncoderSink(subsetMask, sink) {
       this[_subsetMask] = subsetMask;
-      this[_sink] = sink$;
+      this[_sink] = sink;
       super.StringConversionSinkBase();
     }
     close() {
@@ -172,8 +172,8 @@ var convert;
   }
   let _convertInvalid = Symbol('_convertInvalid');
   class _UnicodeSubsetDecoder extends Converter$(core.List$(core.int), core.String) {
-    _UnicodeSubsetDecoder(allowInvalid$, subsetMask) {
-      this[_allowInvalid] = allowInvalid$;
+    _UnicodeSubsetDecoder(allowInvalid, subsetMask) {
+      this[_allowInvalid] = allowInvalid;
       this[_subsetMask] = subsetMask;
       super.Converter();
     }
@@ -294,8 +294,8 @@ var convert;
     }
   }
   class _SimpleAsciiDecoderSink extends ByteConversionSinkBase {
-    _SimpleAsciiDecoderSink(sink$) {
-      this[_sink] = sink$;
+    _SimpleAsciiDecoderSink(sink) {
+      this[_sink] = sink;
       super.ByteConversionSinkBase();
     }
     close() {
@@ -323,8 +323,8 @@ var convert;
     }
   }
   class _ByteAdapterSink extends ByteConversionSinkBase {
-    _ByteAdapterSink(sink$) {
-      this[_sink] = sink$;
+    _ByteAdapterSink(sink) {
+      this[_sink] = sink;
       super.ByteConversionSinkBase();
     }
     add(chunk) {
@@ -382,9 +382,9 @@ var convert;
   let _accumulated = Symbol('_accumulated');
   let _SimpleCallbackSink$ = dart.generic(function(T) {
     class _SimpleCallbackSink extends ChunkedConversionSink$(T) {
-      _SimpleCallbackSink(callback$) {
+      _SimpleCallbackSink(callback) {
         this[_accumulated] = new core.List$(T).from([]);
-        this[_callback] = callback$;
+        this[_callback] = callback;
         super.ChunkedConversionSink();
       }
       add(chunk) {
@@ -399,8 +399,8 @@ var convert;
   let _SimpleCallbackSink = _SimpleCallbackSink$();
   let _EventSinkAdapter$ = dart.generic(function(T) {
     class _EventSinkAdapter extends core.Object {
-      _EventSinkAdapter(sink$) {
-        this[_sink] = sink$;
+      _EventSinkAdapter(sink) {
+        this[_sink] = sink;
       }
       add(data) {
         return this[_sink].add(data);
@@ -447,8 +447,8 @@ var convert;
       get decoder() {
         return dart.as(this[_second].decoder.fuse(this[_first].decoder), Converter$(T, S));
       }
-      _FusedCodec(first$, second) {
-        this[_first] = first$;
+      _FusedCodec(first, second) {
+        this[_first] = first;
         this[_second] = second;
         super.Codec();
       }
@@ -478,8 +478,8 @@ var convert;
   let _InvertedCodec = _InvertedCodec$();
   let _FusedConverter$ = dart.generic(function(S, M, T) {
     class _FusedConverter extends Converter$(S, T) {
-      _FusedConverter(first$, second) {
-        this[_first] = first$;
+      _FusedConverter(first, second) {
+        this[_first] = first;
         this[_second] = second;
         super.Converter();
       }
@@ -494,11 +494,11 @@ var convert;
   });
   let _FusedConverter = _FusedConverter$();
   let HTML_ESCAPE = new HtmlEscape();
-  let _$ = Symbol('_');
+  let _ = Symbol('_');
   let _name = Symbol('_name');
   class HtmlEscapeMode extends core.Object {
-    [_$](name$, escapeLtGt, escapeQuot, escapeApos, escapeSlash) {
-      this[_name] = name$;
+    [_](name, escapeLtGt, escapeQuot, escapeApos, escapeSlash) {
+      this[_name] = name;
       this.escapeLtGt = escapeLtGt;
       this.escapeQuot = escapeQuot;
       this.escapeApos = escapeApos;
@@ -508,10 +508,10 @@ var convert;
       return this[_name];
     }
   }
-  dart.defineNamedConstructor(HtmlEscapeMode, _$);
-  HtmlEscapeMode.UNKNOWN = new HtmlEscapeMode[_$]('unknown', true, true, true, true);
-  HtmlEscapeMode.ATTRIBUTE = new HtmlEscapeMode[_$]('attribute', false, true, false, false);
-  HtmlEscapeMode.ELEMENT = new HtmlEscapeMode[_$]('element', true, false, false, true);
+  dart.defineNamedConstructor(HtmlEscapeMode, _);
+  HtmlEscapeMode.UNKNOWN = new HtmlEscapeMode[_]('unknown', true, true, true, true);
+  HtmlEscapeMode.ATTRIBUTE = new HtmlEscapeMode[_]('attribute', false, true, false, false);
+  HtmlEscapeMode.ELEMENT = new HtmlEscapeMode[_]('element', true, false, false, true);
   let _convert = Symbol('_convert');
   class HtmlEscape extends Converter$(core.String, core.String) {
     HtmlEscape(mode) {
@@ -590,9 +590,9 @@ var convert;
   }
   let _escape = Symbol('_escape');
   class _HtmlEscapeSink extends StringConversionSinkBase {
-    _HtmlEscapeSink(escape, sink$) {
+    _HtmlEscapeSink(escape, sink) {
       this[_escape] = escape;
-      this[_sink] = sink$;
+      this[_sink] = sink;
       super.StringConversionSinkBase();
     }
     addSlice(chunk, start, end, isLast) {
@@ -788,10 +788,10 @@ var convert;
   JsonUtf8Encoder.DEFAULT_BUFFER_SIZE = 256;
   let _isDone = Symbol('_isDone');
   class _JsonEncoderSink extends ChunkedConversionSink$(core.Object) {
-    _JsonEncoderSink(sink$, toEncodable$, indent$) {
-      this[_sink] = sink$;
-      this[_toEncodable$] = toEncodable$;
-      this[_indent] = indent$;
+    _JsonEncoderSink(sink, toEncodable, indent) {
+      this[_sink] = sink;
+      this[_toEncodable$] = toEncodable;
+      this[_indent] = indent;
       this[_isDone] = false;
       super.ChunkedConversionSink();
     }
@@ -808,11 +808,11 @@ var convert;
   }
   let _addChunk = Symbol('_addChunk');
   class _JsonUtf8EncoderSink extends ChunkedConversionSink$(core.Object) {
-    _JsonUtf8EncoderSink(sink$, toEncodable$, indent$, bufferSize$) {
-      this[_sink] = sink$;
-      this[_toEncodable$] = toEncodable$;
-      this[_indent] = indent$;
-      this[_bufferSize] = bufferSize$;
+    _JsonUtf8EncoderSink(sink, toEncodable, indent, bufferSize) {
+      this[_sink] = sink;
+      this[_toEncodable$] = toEncodable;
+      this[_indent] = indent;
+      this[_bufferSize] = bufferSize;
       this[_isDone] = false;
       super.ChunkedConversionSink();
     }
@@ -1096,8 +1096,8 @@ var convert;
   }
   _JsonPrettyPrintMixin[dart.implements] = () => [_JsonStringifier];
   class _JsonStringStringifier extends _JsonStringifier {
-    _JsonStringStringifier(sink$, _toEncodable) {
-      this[_sink] = sink$;
+    _JsonStringStringifier(sink, _toEncodable) {
+      this[_sink] = sink;
       super._JsonStringifier(dart.as(_toEncodable, dart.functionType(core.Object, [core.Object])));
     }
     static stringify(object, toEncodable, indent) {
@@ -1128,8 +1128,8 @@ var convert;
     }
   }
   class _JsonStringStringifierPretty extends dart.mixin(_JsonStringStringifier, _JsonPrettyPrintMixin) {
-    _JsonStringStringifierPretty(sink, toEncodable, indent$) {
-      this[_indent] = indent$;
+    _JsonStringStringifierPretty(sink, toEncodable, indent) {
+      this[_indent] = indent;
       super._JsonStringStringifier(sink, toEncodable);
     }
     writeIndentation(count) {
@@ -1230,9 +1230,9 @@ var convert;
         this.index = 0;
       }
       this.buffer[core.$set]((() => {
-        let x$ = this.index;
-        this.index = dart.notNull(x$) + 1;
-        return x$;
+        let x = this.index;
+        this.index = dart.notNull(x) + 1;
+        return x;
       }).bind(this)(), byte);
     }
   }
@@ -1318,8 +1318,8 @@ var convert;
   }
   let _addSliceToSink = Symbol('_addSliceToSink');
   class _Latin1DecoderSink extends ByteConversionSinkBase {
-    _Latin1DecoderSink(sink$) {
-      this[_sink] = sink$;
+    _Latin1DecoderSink(sink) {
+      this[_sink] = sink;
       super.ByteConversionSinkBase();
     }
     close() {
@@ -1393,8 +1393,8 @@ var convert;
   let _LF = Symbol('_LF');
   let _CR = Symbol('_CR');
   class _LineSplitterSink extends StringConversionSinkBase {
-    _LineSplitterSink(sink$) {
-      this[_sink] = sink$;
+    _LineSplitterSink(sink) {
+      this[_sink] = sink;
       this[_carry] = null;
       super.StringConversionSinkBase();
     }
@@ -1474,9 +1474,9 @@ var convert;
   dart.defineNamedConstructor(ClosableStringSink, 'fromStringSink');
   let _StringSinkCloseCallback = dart.typedef('_StringSinkCloseCallback', () => dart.functionType(dart.void, []));
   class _ClosableStringSink extends core.Object {
-    _ClosableStringSink(sink$, callback$) {
-      this[_sink] = sink$;
-      this[_callback] = callback$;
+    _ClosableStringSink(sink, callback) {
+      this[_sink] = sink;
+      this[_callback] = callback;
     }
     close() {
       return this[_callback]();
@@ -1559,8 +1559,8 @@ var convert;
   _StringConversionSinkAsStringSinkAdapter._MIN_STRING_SIZE = 16;
   let _stringSink = Symbol('_stringSink');
   class _StringSinkConversionSink extends StringConversionSinkBase {
-    _StringSinkConversionSink(stringSink$) {
-      this[_stringSink] = stringSink$;
+    _StringSinkConversionSink(stringSink) {
+      this[_stringSink] = stringSink;
       super.StringConversionSinkBase();
     }
     close() {}
@@ -1586,8 +1586,8 @@ var convert;
     }
   }
   class _StringCallbackSink extends _StringSinkConversionSink {
-    _StringCallbackSink(callback$) {
-      this[_callback] = callback$;
+    _StringCallbackSink(callback) {
+      this[_callback] = callback;
       super._StringSinkConversionSink(new core.StringBuffer());
     }
     close() {
@@ -1601,8 +1601,8 @@ var convert;
     }
   }
   class _StringAdapterSink extends StringConversionSinkBase {
-    _StringAdapterSink(sink$) {
-      this[_sink] = sink$;
+    _StringAdapterSink(sink) {
+      this[_sink] = sink;
       super.StringConversionSinkBase();
     }
     add(str) {
@@ -1623,8 +1623,8 @@ var convert;
   }
   let _decoder = Symbol('_decoder');
   class _Utf8StringSinkAdapter extends ByteConversionSink {
-    _Utf8StringSinkAdapter(sink$, stringSink, allowMalformed) {
-      this[_sink] = sink$;
+    _Utf8StringSinkAdapter(sink, stringSink, allowMalformed) {
+      this[_sink] = sink;
       this[_decoder] = new _Utf8Decoder(stringSink, allowMalformed);
       super.ByteConversionSink();
     }
@@ -1644,9 +1644,9 @@ var convert;
   }
   class _Utf8ConversionSink extends ByteConversionSink {
     _Utf8ConversionSink(sink, allowMalformed) {
-      this[_$](sink, new core.StringBuffer(), allowMalformed);
+      this[_](sink, new core.StringBuffer(), allowMalformed);
     }
-    [_$](chunkedSink, stringBuffer, allowMalformed) {
+    [_](chunkedSink, stringBuffer, allowMalformed) {
       this[_chunkedSink] = chunkedSink;
       this[_decoder] = new _Utf8Decoder(stringBuffer, allowMalformed);
       this[_buffer] = stringBuffer;
@@ -1677,7 +1677,7 @@ var convert;
         this.close();
     }
   }
-  dart.defineNamedConstructor(_Utf8ConversionSink, _$);
+  dart.defineNamedConstructor(_Utf8ConversionSink, _);
   let UNICODE_REPLACEMENT_CHARACTER_RUNE = 65533;
   let UNICODE_BOM_CHARACTER_RUNE = 65279;
   let UTF8 = new Utf8Codec();
@@ -1763,41 +1763,41 @@ var convert;
         dart.assert(dart.notNull(rune) > dart.notNull(_THREE_BYTE_LIMIT));
         dart.assert(dart.notNull(rune) <= dart.notNull(_FOUR_BYTE_LIMIT));
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 240 | dart.notNull(rune) >> 18);
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 128 | dart.notNull(rune) >> 12 & 63);
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 128 | dart.notNull(rune) >> 6 & 63);
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 128 | dart.notNull(rune) & 63);
         return true;
       } else {
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 224 | dart.notNull(leadingSurrogate) >> 12);
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 128 | dart.notNull(leadingSurrogate) >> 6 & 63);
         this[_buffer][core.$set]((() => {
-          let x$ = this[_bufferIndex];
-          this[_bufferIndex] = dart.notNull(x$) + 1;
-          return x$;
+          let x = this[_bufferIndex];
+          this[_bufferIndex] = dart.notNull(x) + 1;
+          return x;
         }).bind(this)(), 128 | dart.notNull(leadingSurrogate) & 63);
         return false;
       }
@@ -1813,9 +1813,9 @@ var convert;
           if (dart.notNull(this[_bufferIndex]) >= dart.notNull(this[_buffer][core.$length]))
             break;
           this[_buffer][core.$set]((() => {
-            let x$ = this[_bufferIndex];
-            this[_bufferIndex] = dart.notNull(x$) + 1;
-            return x$;
+            let x = this[_bufferIndex];
+            this[_bufferIndex] = dart.notNull(x) + 1;
+            return x;
           }).bind(this)(), codeUnit);
         } else if (_isLeadSurrogate(codeUnit)) {
           if (dart.notNull(this[_bufferIndex]) + 3 >= dart.notNull(this[_buffer][core.$length]))
@@ -1831,33 +1831,33 @@ var convert;
             if (dart.notNull(this[_bufferIndex]) + 1 >= dart.notNull(this[_buffer][core.$length]))
               break;
             this[_buffer][core.$set]((() => {
-              let x$ = this[_bufferIndex];
-              this[_bufferIndex] = dart.notNull(x$) + 1;
-              return x$;
+              let x = this[_bufferIndex];
+              this[_bufferIndex] = dart.notNull(x) + 1;
+              return x;
             }).bind(this)(), 192 | dart.notNull(rune) >> 6);
             this[_buffer][core.$set]((() => {
-              let x$ = this[_bufferIndex];
-              this[_bufferIndex] = dart.notNull(x$) + 1;
-              return x$;
+              let x = this[_bufferIndex];
+              this[_bufferIndex] = dart.notNull(x) + 1;
+              return x;
             }).bind(this)(), 128 | dart.notNull(rune) & 63);
           } else {
             dart.assert(dart.notNull(rune) <= dart.notNull(_THREE_BYTE_LIMIT));
             if (dart.notNull(this[_bufferIndex]) + 2 >= dart.notNull(this[_buffer][core.$length]))
               break;
             this[_buffer][core.$set]((() => {
-              let x$ = this[_bufferIndex];
-              this[_bufferIndex] = dart.notNull(x$) + 1;
-              return x$;
+              let x = this[_bufferIndex];
+              this[_bufferIndex] = dart.notNull(x) + 1;
+              return x;
             }).bind(this)(), 224 | dart.notNull(rune) >> 12);
             this[_buffer][core.$set]((() => {
-              let x$ = this[_bufferIndex];
-              this[_bufferIndex] = dart.notNull(x$) + 1;
-              return x$;
+              let x = this[_bufferIndex];
+              this[_bufferIndex] = dart.notNull(x) + 1;
+              return x;
             }).bind(this)(), 128 | dart.notNull(rune) >> 6 & 63);
             this[_buffer][core.$set]((() => {
-              let x$ = this[_bufferIndex];
-              this[_bufferIndex] = dart.notNull(x$) + 1;
-              return x$;
+              let x = this[_bufferIndex];
+              this[_bufferIndex] = dart.notNull(x) + 1;
+              return x;
             }).bind(this)(), 128 | dart.notNull(rune) & 63);
           }
         }
@@ -1868,8 +1868,8 @@ var convert;
   dart.defineNamedConstructor(_Utf8Encoder, 'withBufferSize');
   _Utf8Encoder._DEFAULT_BYTE_BUFFER_SIZE = 1024;
   class _Utf8EncoderSink extends dart.mixin(_Utf8Encoder, StringConversionSinkMixin) {
-    _Utf8EncoderSink(sink$) {
-      this[_sink] = sink$;
+    _Utf8EncoderSink(sink) {
+      this[_sink] = sink;
       super._Utf8Encoder();
     }
     close() {
@@ -1985,9 +1985,9 @@ var convert;
   let _extraUnits = Symbol('_extraUnits');
   let _LIMITS = Symbol('_LIMITS');
   class _Utf8Decoder extends core.Object {
-    _Utf8Decoder(stringSink$, allowMalformed$) {
-      this[_stringSink] = stringSink$;
-      this[_allowMalformed] = allowMalformed$;
+    _Utf8Decoder(stringSink, allowMalformed) {
+      this[_stringSink] = stringSink;
+      this[_allowMalformed] = allowMalformed;
       this[_isFirstCharacter] = true;
       this[_value] = 0;
       this[_expectedUnits] = 0;
@@ -2086,9 +2086,9 @@ var convert;
                 break;
             }
             let unit = codeUnits[core.$get]((() => {
-              let x$ = i;
-              i = dart.notNull(x$) + 1;
-              return x$;
+              let x = i;
+              i = dart.notNull(x) + 1;
+              return x;
             })());
             if (dart.notNull(unit) < 0) {
               if (!dart.notNull(this[_allowMalformed])) {
@@ -2190,9 +2190,9 @@ var convert;
   let _hasProperty = Symbol('_hasProperty');
   let _getPropertyNames = Symbol('_getPropertyNames');
   class _JsonMap extends core.Object {
-    _JsonMap(original$) {
+    _JsonMap(original) {
       this[_processed] = _JsonMap[_newJavaScriptObject]();
-      this[_original] = original$;
+      this[_original] = original;
       this[_data] = null;
     }
     get(key) {
@@ -2386,9 +2386,9 @@ var convert;
     }
   }
   class _JsonDecoderSink extends _StringSinkConversionSink {
-    _JsonDecoderSink(reviver$, sink$) {
-      this[_reviver] = reviver$;
-      this[_sink] = sink$;
+    _JsonDecoderSink(reviver, sink) {
+      this[_reviver] = reviver;
+      this[_sink] = sink;
       super._StringSinkConversionSink(new core.StringBuffer());
     }
     close() {

--- a/lib/runtime/dart/core.js
+++ b/lib/runtime/dart/core.js
@@ -100,7 +100,7 @@ var core;
     return Comparable;
   });
   let Comparable = Comparable$();
-  let _internal$ = dart.JsSymbol('_internal');
+  let _internal = dart.JsSymbol('_internal');
   let _now = dart.JsSymbol('_now');
   let _brokenDownDateToMillisecondsSinceEpoch = dart.JsSymbol('_brokenDownDateToMillisecondsSinceEpoch');
   let _MAX_MILLISECONDS_SINCE_EPOCH = dart.JsSymbol('_MAX_MILLISECONDS_SINCE_EPOCH');
@@ -122,7 +122,7 @@ var core;
         second = 0;
       if (millisecond === void 0)
         millisecond = 0;
-      this[_internal$](year, month, day, hour, minute, second, millisecond, false);
+      this[_internal](year, month, day, hour, minute, second, millisecond, false);
     }
     utc(year, month, day, hour, minute, second, millisecond) {
       if (month === void 0)
@@ -137,7 +137,7 @@ var core;
         second = 0;
       if (millisecond === void 0)
         millisecond = 0;
-      this[_internal$](year, month, day, hour, minute, second, millisecond, true);
+      this[_internal](year, month, day, hour, minute, second, millisecond, true);
     }
     now() {
       this[_now]();
@@ -306,7 +306,7 @@ var core;
       let otherMs = other.millisecondsSinceEpoch;
       return new Duration({milliseconds: dart.notNull(ms) - dart.notNull(otherMs)});
     }
-    [_internal$](year, month, day, hour, minute, second, millisecond, isUtc) {
+    [_internal](year, month, day, hour, minute, second, millisecond, isUtc) {
       this.isUtc = typeof isUtc == 'boolean' ? isUtc : dart.throw_(new ArgumentError(isUtc));
       this.millisecondsSinceEpoch = dart.as(_js_helper.checkInt(_js_helper.Primitives.valueFromDecomposedDate(year, month, day, hour, minute, second, millisecond, isUtc)), int);
     }
@@ -356,7 +356,7 @@ var core;
   dart.defineNamedConstructor(DateTime, 'utc');
   dart.defineNamedConstructor(DateTime, 'now');
   dart.defineNamedConstructor(DateTime, 'fromMillisecondsSinceEpoch');
-  dart.defineNamedConstructor(DateTime, _internal$);
+  dart.defineNamedConstructor(DateTime, _internal);
   dart.defineNamedConstructor(DateTime, _now);
   DateTime.MONDAY = 1;
   DateTime.TUESDAY = 2;
@@ -435,8 +435,8 @@ var core;
       let microseconds = opts && 'microseconds' in opts ? opts.microseconds : 0;
       this[_microseconds](dart.notNull(days) * dart.notNull(Duration.MICROSECONDS_PER_DAY) + dart.notNull(hours) * dart.notNull(Duration.MICROSECONDS_PER_HOUR) + dart.notNull(minutes) * dart.notNull(Duration.MICROSECONDS_PER_MINUTE) + dart.notNull(seconds) * dart.notNull(Duration.MICROSECONDS_PER_SECOND) + dart.notNull(milliseconds) * dart.notNull(Duration.MICROSECONDS_PER_MILLISECOND) + dart.notNull(microseconds));
     }
-    [_microseconds](duration$) {
-      this[_duration] = duration$;
+    [_microseconds](duration) {
+      this[_duration] = duration;
     }
     ['+'](other) {
       return new Duration[_microseconds](dart.notNull(this[_duration]) + dart.notNull(other[_duration]));
@@ -1138,16 +1138,16 @@ var core;
   let $take = dart.JsSymbol('$take');
   let _GeneratorIterable$ = dart.generic(function(E) {
     class _GeneratorIterable extends collection.IterableBase$(E) {
-      _GeneratorIterable(end$, generator) {
-        this[_end] = end$;
+      _GeneratorIterable(end, generator) {
+        this[_end] = end;
         this[_start] = 0;
         this[_generator] = dart.as(generator != null ? generator : _GeneratorIterable[_id], _Generator);
         super.IterableBase();
       }
-      slice(start$, end$, generator$) {
-        this[_start] = start$;
-        this[_end] = end$;
-        this[_generator] = generator$;
+      slice(start, end, generator) {
+        this[_start] = start;
+        this[_end] = end;
+        this[_generator] = generator;
         super.IterableBase();
       }
       get [exports.$iterator]() {
@@ -1187,10 +1187,10 @@ var core;
   let _current = dart.JsSymbol('_current');
   let _GeneratorIterator$ = dart.generic(function(E) {
     class _GeneratorIterator extends Object {
-      _GeneratorIterator(index$, end$, generator$) {
-        this[_index] = index$;
-        this[_end] = end$;
-        this[_generator] = generator$;
+      _GeneratorIterator(index, end, generator) {
+        this[_index] = index;
+        this[_end] = end;
+        this[_generator] = generator;
         this[_current] = null;
       }
       moveNext() {
@@ -1959,19 +1959,19 @@ var core;
       } else if (char == Uri[_NUMBER_SIGN]) {
         fragment = Uri[_makeFragment](uri, dart.notNull(index) + 1, uri.length);
       }
-      return new Uri[_internal$](scheme, userinfo, host, port, path, query, fragment);
+      return new Uri[_internal](scheme, userinfo, host, port, path, query, fragment);
     }
     static [_fail](uri, index, message) {
       throw new FormatException(message, uri, index);
     }
-    [_internal$](scheme, userInfo$, host$, port$, path$, query$, fragment$) {
+    [_internal](scheme, userInfo, host, port, path, query, fragment) {
       this.scheme = scheme;
-      this[_userInfo] = userInfo$;
-      this[_host] = host$;
-      this[_port] = port$;
-      this[_path] = path$;
-      this[_query] = query$;
-      this[_fragment] = fragment$;
+      this[_userInfo] = userInfo;
+      this[_host] = host;
+      this[_port] = port;
+      this[_path] = path;
+      this[_query] = query;
+      this[_fragment] = fragment;
       this[_pathSegments] = null;
       this[_queryParameters] = null;
     }
@@ -1999,7 +1999,7 @@ var core;
       }
       let ensureLeadingSlash = host != null;
       path = Uri[_makePath](path, 0, Uri[_stringOrNullLength](path), pathSegments, ensureLeadingSlash, isFile);
-      return new Uri[_internal$](scheme, userInfo, host, port, path, query, fragment);
+      return new Uri[_internal](scheme, userInfo, host, port, path, query, fragment);
     }
     http(authority, unencodedPath, queryParameters) {
       if (queryParameters === void 0)
@@ -2209,7 +2209,7 @@ var core;
       } else if (this.hasFragment) {
         fragment = this.fragment;
       }
-      return new Uri[_internal$](scheme, userInfo, host, port, path, query, fragment);
+      return new Uri[_internal](scheme, userInfo, host, port, path, query, fragment);
     }
     get pathSegments() {
       if (this[_pathSegments] == null) {
@@ -2643,7 +2643,7 @@ var core;
         }
       }
       let fragment = reference.hasFragment ? reference.fragment : null;
-      return new Uri[_internal$](targetScheme, targetUserInfo, targetHost, targetPort, targetPath, targetQuery, fragment);
+      return new Uri[_internal](targetScheme, targetUserInfo, targetHost, targetPort, targetPath, targetQuery, fragment);
     }
     get hasAuthority() {
       return this[_host] != null;
@@ -3003,7 +3003,7 @@ var core;
       return dart.notNull(codeUnit) >= dart.notNull(Uri[_LOWER_CASE_A]) && dart.notNull(codeUnit) <= dart.notNull(Uri[_LOWER_CASE_Z]) || dart.notNull(codeUnit) >= dart.notNull(Uri[_UPPER_CASE_A]) && dart.notNull(codeUnit) <= dart.notNull(Uri[_UPPER_CASE_Z]);
     }
   }
-  dart.defineNamedConstructor(Uri, _internal$);
+  dart.defineNamedConstructor(Uri, _internal);
   dart.defineNamedConstructor(Uri, 'http');
   dart.defineNamedConstructor(Uri, 'https');
   dart.defineNamedConstructor(Uri, 'file');

--- a/lib/src/codegen/js_codegen.dart
+++ b/lib/src/codegen/js_codegen.dart
@@ -64,10 +64,11 @@ class JSCodegenVisitor extends GeneralizingAstVisitor with ConversionVisitor {
   final _exports = new Set<String>();
   final _lazyFields = <VariableDeclaration>[];
   final _properties = <FunctionDeclaration>[];
-  final _privateNames = new HashSet<String>();
-  final _pendingPrivateNames = <String>[];
+  final _privateNames = new HashMap<String, JSTemporary>();
+  final _pendingPrivateNames = <JSTemporary>[];
   final _extensionMethodNames = new HashSet<String>();
   final _pendingExtensionMethodNames = <String>[];
+  final _temps = new HashMap<Element, JSTemporary>();
 
   /// The name for the library's exports inside itself.
   /// This much be a constant because we interpolate it into template strings,
@@ -144,8 +145,8 @@ class JSCodegenVisitor extends GeneralizingAstVisitor with ConversionVisitor {
     ]);
   }
 
-  JS.Statement _initPrivateSymbol(String name) => js.statement(
-      'let # = $_SYMBOL(#);', [new JSTemporary(name), js.string(name, "'")]);
+  JS.Statement _initPrivateSymbol(JSTemporary tmp) =>
+      js.statement('let # = $_SYMBOL(#);', [tmp, js.string(tmp.name, "'")]);
 
   JS.Statement _initExtensionMethodSymbol(String name) => js.statement(
       'let # = $_SYMBOL(#);', [new JS.Identifier(name), js.string(name, "'")]);
@@ -1025,19 +1026,22 @@ class JSCodegenVisitor extends GeneralizingAstVisitor with ConversionVisitor {
       /// Rename private names so they don't shadow the private field symbol.
       /// The renamer would handle this, but it would prefer to rename the
       /// temporary used for the private symbol. Instead rename the parameter.
-      return new JSTemporary('${name.substring(1)}');
+      return _getTemp(e, '${name.substring(1)}');
     }
 
     if (_isTemporary(e)) {
       if (name[0] == '#') {
         return new JS.InterpolatedExpression(name.substring(1));
       } else {
-        return new JSTemporary(name);
+        return _getTemp(e, name);
       }
     }
 
     return new JS.Identifier(name);
   }
+
+  JSTemporary _getTemp(Object key, String name) =>
+      _temps.putIfAbsent(key, () => new JSTemporary(name));
 
   JS.ArrayInitializer _emitTypeNames(List<DartType> types) {
     return new JS.ArrayInitializer(types.map(_emitTypeName).toList());
@@ -1211,7 +1215,7 @@ class JSCodegenVisitor extends GeneralizingAstVisitor with ConversionVisitor {
     // TODO(jmesserly): if we try to call a getter returning a function with
     // a call method, we don't generate the `.call` correctly.
     String code;
-    if (target == null) {
+    if (target == null || isLibraryPrefix(target)) {
       if (rules.isDynamicCall(node.methodName)) {
         code = 'dart.$DCALL(#, #)';
       } else {
@@ -1773,7 +1777,7 @@ class JSCodegenVisitor extends GeneralizingAstVisitor with ConversionVisitor {
 
   @override
   visitPrefixedIdentifier(PrefixedIdentifier node) {
-    if (node.prefix.staticElement is PrefixElement) {
+    if (isLibraryPrefix(node.prefix)) {
       return _visit(node.identifier);
     } else {
       return _emitGet(node.prefix, node.identifier.name);
@@ -2206,8 +2210,11 @@ class JSCodegenVisitor extends GeneralizingAstVisitor with ConversionVisitor {
   JS.Expression _emitMemberName(String name,
       {DartType type, bool unary: false, bool isStatic: false}) {
     if (name.startsWith('_')) {
-      if (_privateNames.add(name)) _pendingPrivateNames.add(name);
-      return new JSTemporary(name);
+      return _privateNames.putIfAbsent(name, () {
+        var t = new JSTemporary(name);
+        _pendingPrivateNames.add(t);
+        return t;
+      });
     }
     // Check for extension method:
     var extLibrary = _findExtensionLibrary(name, type);

--- a/lib/src/js/printer.dart
+++ b/lib/src/js/printer.dart
@@ -506,7 +506,7 @@ class Printer implements NodeVisitor {
     blockBody(node.body, needsSeparation: false, needsNewline: true);
   }
 
-  void functionOut(Fun fun, Node name, Node scope) {
+  void functionOut(Fun fun, Node name) {
     out("function");
     if (name != null) {
       out(" ");
@@ -514,7 +514,7 @@ class Printer implements NodeVisitor {
       visitNestedExpression(name, PRIMARY,
                             newInForInit: false, newAtStatementBegin: false);
     }
-    localNamer.enterScope(scope);
+    localNamer.enterScope(fun);
     out("(");
     if (fun.params != null) {
       visitCommaSeparated(fun.params, PRIMARY,
@@ -540,7 +540,7 @@ class Printer implements NodeVisitor {
 
   visitFunctionDeclaration(FunctionDeclaration declaration) {
     indent();
-    functionOut(declaration.function, declaration.name, declaration);
+    functionOut(declaration.function, declaration.name);
     lineOut();
   }
 
@@ -816,11 +816,11 @@ class Printer implements NodeVisitor {
   }
 
   visitNamedFunction(NamedFunction namedFunction) {
-    functionOut(namedFunction.function, namedFunction.name, namedFunction);
+    functionOut(namedFunction.function, namedFunction.name);
   }
 
   visitFun(Fun fun) {
-    functionOut(fun, null, fun);
+    functionOut(fun, null);
   }
 
   visitArrowFun(ArrowFun fun) {
@@ -1000,9 +1000,9 @@ class Printer implements NodeVisitor {
     }
     propertyNameOut(node.name, inMethod: true);
 
-    localNamer.enterScope(node);
-    out("(");
     var fun = node.function;
+    localNamer.enterScope(fun);
+    out("(");
     if (fun.params != null) {
       visitCommaSeparated(fun.params, PRIMARY,
           newInForInit: false, newAtStatementBegin: false);
@@ -1164,7 +1164,6 @@ class VarCollector extends BaseVisitor {
   }
 
   void visitMethod(Method declaration) {
-    // Method names are qualified by the instance, so we don't collect them.
     collectVarsInFunction(declaration.function);
   }
 
@@ -1253,14 +1252,14 @@ class DanglingElseVisitor extends BaseVisitor<bool> {
 
 abstract class LocalNamer {
   String getName(Identifier node);
-  void enterScope(Node node);
+  void enterScope(FunctionExpression node);
   void leaveScope();
 }
 
 
 class IdentityNamer implements LocalNamer {
   String getName(Identifier node) => node.name;
-  void enterScope(Node node) {}
+  void enterScope(FunctionExpression node) {}
   void leaveScope() {}
 }
 
@@ -1272,7 +1271,7 @@ class MinifyRenamer implements LocalNamer {
   int parameterNumber = 0;
   int variableNumber = 0;
 
-  void enterScope(Node node) {
+  void enterScope(FunctionExpression node) {
     var vars = new VarCollector();
     node.accept(vars);
     maps.add(new Map<String, String>());

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -205,11 +205,11 @@ _MemberTypeGetter _memberTypeGetter(ExecutableElement member) {
   return f;
 }
 
-bool isDynamicTarget(Expression target) {
-  return target != null &&
-      !(target is SimpleIdentifier && target.staticElement is PrefixElement) &&
-      target.staticType.isDynamic;
-}
+bool isDynamicTarget(Expression node) =>
+    node != null && !isLibraryPrefix(node) && node.staticType.isDynamic;
+
+bool isLibraryPrefix(Expression node) =>
+    node is SimpleIdentifier && node.staticElement is PrefixElement;
 
 /// Returns an ANSII color escape sequence corresponding to [levelName]. Colors
 /// are defined for: severe, error, warning, or info. Returns null if the level

--- a/test/codegen/expect/opassign.js
+++ b/test/codegen/expect/opassign.js
@@ -30,21 +30,21 @@ var opassign;
     let i = exports.index;
     f.set(i, dart.dsend(f.get(i), '+', 1));
     forcePostfix((() => {
-      let i = exports.index, x$ = f.get(i);
-      f.set(i, dart.dsend(x$, '+', 1));
-      return x$;
+      let i = exports.index, x = f.get(i);
+      f.set(i, dart.dsend(x, '+', 1));
+      return x;
     })());
     core.print('should only call "foo" 2 times:');
     let o = exports.foo;
     dart.dput(o, 'x', dart.dsend(dart.dload(o, 'x'), '+', 1));
     forcePostfix((() => {
-      let o = exports.foo, x$ = dart.dload(o, 'x');
-      dart.dput(o, 'x', dart.dsend(x$, '+', 1));
-      return x$;
+      let o = exports.foo, x = dart.dload(o, 'x');
+      dart.dput(o, 'x', dart.dsend(x, '+', 1));
+      return x;
     })());
     core.print('op assign test, should only call "index" twice:');
-    let i = exports.index;
-    f.set(i, dart.dsend(f.get(i), '+', f.get(exports.index)));
+    let i$ = exports.index;
+    f.set(i$, dart.dsend(f.get(i$), '+', f.get(exports.index)));
   }
   // Function forcePostfix: (dynamic) → dynamic
   function forcePostfix(x) {

--- a/test/codegen/expect/temps.js
+++ b/test/codegen/expect/temps.js
@@ -1,0 +1,21 @@
+var temps;
+(function(exports) {
+  'use strict';
+  let _x = Symbol('_x');
+  let __x = Symbol('__x');
+  let _function = Symbol('_function');
+  class FormalCollision extends core.Object {
+    FormalCollision(x, _x$, func) {
+      this[_x] = x;
+      this[__x] = _x$;
+      this[_function] = func;
+    }
+  }
+  // Function main: () → dynamic
+  function main() {
+    core.print(new FormalCollision(1, 2, x => x));
+  }
+  // Exports:
+  exports.FormalCollision = FormalCollision;
+  exports.main = main;
+})(temps || (temps = {}));

--- a/test/codegen/expect/temps.txt
+++ b/test/codegen/expect/temps.txt
@@ -1,0 +1,1 @@
+// Messages from compiling temps.dart

--- a/test/codegen/temps.dart
+++ b/test/codegen/temps.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class FormalCollision {
+  // These shouldn't collide (see issue #136)
+  int _x, __x;
+  // This shouldn't generate a keyword as an identifier.
+  Function _function;
+  FormalCollision(this._x, this.__x, this._function);
+}
+
+main() {
+  print(new FormalCollision(1, 2, (x) => x));
+}


### PR DESCRIPTION
JSTemporary is now identified by instance, not its String name. This provides enough information to do renaming correctly and avoid the bug in #136.

The namer now considers all scopes where the temporary is visible, and chooses a name that doesn't conflict with other identifiers. Because it only considers scopes where the temp appears, it does less renaming that the previous version.