### PR TITLE
Fix dart.equals("10", 10) (issue #210)

### DIFF
--- a/lib/runtime/dart_runtime.js
+++ b/lib/runtime/dart_runtime.js
@@ -423,7 +423,7 @@ var dart, dartx;
   function equals(x, y) {
     if (x == null || y == null) return x == y;
     let eq = x['=='];
-    return eq ? eq.call(x, y) : x == y;
+    return eq ? eq.call(x, y) : x === y;
   }
   dart.equals = equals;
 


### PR DESCRIPTION
See doc on == vs. === : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators
Note that the `== null` tests in the same function are probably preferable to `=== null` if both undefined and null values can be encountered.