### PR TITLE
Fix compilation of `x ~/ y` (use Math.trunc instead of hitting Number.truncate())

### DIFF
--- a/lib/src/codegen/js_codegen.dart
+++ b/lib/src/codegen/js_codegen.dart
@@ -2014,7 +2014,7 @@ class JSCodegenVisitor extends GeneralizingAstVisitor {
       // instead of special cases here.
       if (op.type == TokenType.TILDE_SLASH) {
         // `a ~/ b` is equivalent to `(a / b).truncate()`
-        code = '(# / #).truncate()';
+        code = 'Math.trunc(# / #)';
       } else {
         // TODO(vsm): When do Dart ops not map to JS?
         code = '# $op #';


### PR DESCRIPTION
….truncate())