### PR TITLE
add a bin/dev_compiler.dart entrypoint

### DIFF
--- a/bin/dev_compiler.dart
+++ b/bin/dev_compiler.dart
@@ -1,0 +1,8 @@
+#!/usr/bin/env dart
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'devc.dart' as devc;
+
+main(args) => devc.main(args);


### PR DESCRIPTION
Add a bin/dev_compiler.dart entrypoint, so that something like:

    pub global run dev_compiler foo/bar.dart

will work, in addition to `dartdevc foo/bar.dart`.