### PR TITLE
catch parse exceptions from args

### DIFF
--- a/bin/dartdevc.dart
+++ b/bin/dartdevc.dart
@@ -23,7 +23,15 @@ void _showUsageAndExit() {
 }
 
 main(List<String> args) async {
-  var options = validateOptions(args);
+  var options;
+
+  try {
+    options = validateOptions(args);
+  } on FormatException catch (e) {
+    print('${e.message}\n');
+    _showUsageAndExit();
+  }
+
   if (options == null || options.help) _showUsageAndExit();
 
   setupLogger(options.logLevel, print);

--- a/bin/devrun.dart
+++ b/bin/devrun.dart
@@ -29,10 +29,17 @@ main(List<String> args) async {
     ..add('--arrow-fn-bind-this')
     ..addAll(args);
 
-  CompilerOptions options = validateOptions(args, forceOutDir: true);
-  if (options == null || options.help) {
+  CompilerOptions options;
+
+  try {
+    options = validateOptions(args, forceOutDir: true);
+  } on FormatException catch (e) {
+    print('${e.message}\n');
     _showUsageAndExit();
   }
+
+  if (options == null || options.help) _showUsageAndExit();
+
   if (options.inputs.length != 1) {
     stderr.writeln("Please only specify one input to run");
     _showUsageAndExit();


### PR DESCRIPTION
Catch parse exceptions from the `args` package; print the error message and usage, then exit (current behavior is to print a stacktrace to stdout/stderr). Related to https://github.com/dart-lang/dev_compiler/issues/321.