### PR TITLE
make dev_compiler slightly happier with dartdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ packages
 .idea/
 .pub/
 node_modules
+doc/api/
 
 # Ignore test output
 test/codegen/expect/dev_compiler/

--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@ The Dart Dev Compiler (DDC) is an **experimental** development tool and transpil
 
 DDC attempts to map to idiomatic EcmaScript 6 (ES6) as cleanly as possible.  To do this while cohering to Dart semantics, DDC relies heavily on static type information, static checking, and runtime assertions.
 
-DDC is intended to support [a very large subset of Dart](https://github.com/dart-lang/dev_compiler/blob/master/STRONG_MODE.md).  If a program does not statically check, DDC will not result in valid generated code.  Our goal is that a program execution (of a valid program) that runs without triggering runtime assertions should run the same on other Dart platforms under checked mode or production mode.
+DDC is intended to support a very [large subset](https://github.com/dart-lang/dev_compiler/blob/master/STRONG_MODE.md) of Dart.  If a program does not statically check, DDC will not result in valid generated code.  Our goal is that a program execution (of a valid program) that runs without triggering runtime assertions should run the same on other Dart platforms under checked mode or production mode.
 
 DDC does support untyped Dart code, but it will typically result in less readable and less efficient ES6 output.
 
 DDC has the following project goals:
+
 - Effective static checking and error detection.
 - A debugging solution for all modern browsers.
 - Readable output.
 - Fast, modular compilation of Dart code.
 - Easy use of generated code from JavaScript.
 
-DDC is still in a very early stage as highlighted by our choice of ES6.  ES6 itself is in active development across all modern browsers, but at various stages of support: https://kangax.github.io/compat-table/es6/
+DDC is still in a very early stage as highlighted by our choice of ES6.  ES6 itself is in active development across all modern browsers, but at various stages of support:
+[kangax.github.io/compat-table/es6](https://kangax.github.io/compat-table/es6/).
 
 We are initially targeting the subset of ES6 supported in Chrome Canary.
 
-To try out DDC and/or give feedback, please read our [Usage](https://github.com/dart-lang/dev_compiler/blob/master/USAGE.md) page.
+To try out DDC and/or give feedback, please read our [usage](https://github.com/dart-lang/dev_compiler/blob/master/USAGE.md) page.

--- a/lib/devc.dart
+++ b/lib/devc.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// The main library for the Dart Dev Compiler.
 library dev_compiler.devc;
 
 export 'src/analysis_context.dart'

--- a/lib/runtime/messages_widget.dart
+++ b/lib/runtime/messages_widget.dart
@@ -2,16 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// This library provides a single function called injectLogs which when called
-/// will request a logs json file and build a small widget out of them which
-/// groups the logs by level.
-library polymer.build.log_injector;
+/// This library displays [MessageSummary]s from the Dart Dev Compiler.
+library dev_compiler.messages;
 
 import 'dart:convert';
 import 'dart:html';
 
-import 'package:source_span/source_span.dart';
 import 'package:dev_compiler/src/summary.dart';
+import 'package:source_span/source_span.dart';
 
 main() async {
   await window.animationFrame;

--- a/lib/strong_mode.dart
+++ b/lib/strong_mode.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Types needed to implement "strong" checking in the Dart analyzer.
-/// This is intended to be used by analyzer_cli and analysis_server packages.
+/// Types needed to implement "strong" checking in the Dart analyzer. This is
+/// intended to be used by `analyzer_cli` and `analysis_server` packages.
 library dev_compiler.strong_mode;
 
 import 'package:analyzer/src/generated/engine.dart'


### PR DESCRIPTION
Not critical, but this PR makes dartdoc slightly happier when generating docs for dev_compiler.

Somewhat related, should `lib/runtime/messages_widget.dart` be moved out of `lib/`? It seems like only its output needs to be in `lib/runtime/`.