### PR TITLE
finish rename of devc.dart to dartdevc.dart

### DIFF
--- a/bin/edit_files.dart
+++ b/bin/edit_files.dart
@@ -5,7 +5,7 @@
 
 /// Command line tool to write checker errors as inline comments in the source
 /// code of the program. This tool requires the info.json file created by
-/// running devc.dart passing the arguments
+/// running dartdevc.dart passing the arguments
 /// --dump-info --dump-info-file info.json
 
 library dev_compiler.bin.edit_files;

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -9,11 +9,11 @@ function fail {
   return 1
 }
 
-# Run analyzer on bin/devc.dart, as it includes most of the code we care about
-# via transitive dependencies. This seems to be the only fast way to avoid
+# Run analyzer on bin/dartdevc.dart, as it includes most of the code we care
+# about via transitive dependencies. This seems to be the only fast way to avoid
 # repeated analysis of the same code.
 # TODO(jmesserly): ideally we could do test/all_tests.dart, but
 # dart_runtime_test.dart creates invalid generic type instantiation AA.
 echo "Running dartanalyzer to check for errors/warnings/hints..."
-dartanalyzer --fatal-warnings --package-warnings bin/devc.dart \
+dartanalyzer --fatal-warnings --package-warnings bin/dartdevc.dart \
     | (! grep $PWD) || fail

--- a/tool/build_sdk.sh
+++ b/tool/build_sdk.sh
@@ -8,7 +8,7 @@ dart -c tool/patch_sdk.dart tool/input_sdk tool/generated_sdk
 
 echo "*** Compiling SDK to JavaScript"
 
-dart -c bin/devc.dart --no-source-maps --arrow-fn-bind-this --sdk-check \
+dart -c bin/dartdevc.dart --no-source-maps --arrow-fn-bind-this --sdk-check \
     --force-compile -l warning --dart-sdk tool/generated_sdk -o lib/runtime/ \
     "$@" \
     dart:js dart:mirrors \


### PR DESCRIPTION
Finish rename of devc.dart to dartdevc.dart (from https://github.com/dart-lang/dev_compiler/pull/325). It looks like I missed some references in the `presubmit.sh` script. Not sure how the travis build stayed green; it did catch a failure here: https://travis-ci.org/dart-lang/dev_compiler#L500. For some reason the exit code didn't cause an immediate failure.

