### PR TITLE
add a --version option

### DIFF
--- a/bin/dartdevc.dart
+++ b/bin/dartdevc.dart
@@ -9,10 +9,13 @@ library dev_compiler.bin.dartdevc;
 
 import 'dart:io';
 
+import 'package:dev_compiler/devc.dart' show devCompilerVersion;
 import 'package:dev_compiler/src/compiler.dart'
     show validateOptions, compile, setupLogger;
 import 'package:dev_compiler/src/options.dart';
 import 'package:dev_compiler/src/server/server.dart' show DevServer;
+
+const String _appName = 'dartdevc';
 
 void _showUsageAndExit() {
   print('usage: dartdevc [<options>] <file.dart>...\n');
@@ -33,6 +36,10 @@ main(List<String> args) async {
   }
 
   if (options == null || options.help) _showUsageAndExit();
+  if (options.version) {
+    print('${_appName} version ${devCompilerVersion}');
+    exit(0);
+  }
 
   setupLogger(options.logLevel, print);
 

--- a/bin/devrun.dart
+++ b/bin/devrun.dart
@@ -8,6 +8,7 @@ library dev_compiler.bin.devrun;
 
 import 'dart:io';
 
+import 'package:dev_compiler/devc.dart' show devCompilerVersion;
 import 'package:dev_compiler/src/compiler.dart' show validateOptions, compile;
 import 'package:dev_compiler/src/options.dart';
 import 'package:dev_compiler/src/runner/runtime_utils.dart'
@@ -16,8 +17,10 @@ import 'package:dev_compiler/src/runner/v8_runner.dart' show V8Runner;
 
 import 'package:path/path.dart';
 
+const String _appName = 'dartdevrun';
+
 void _showUsageAndExit() {
-  print('usage: dartdevrun [<options>] <file.dart>\n');
+  print('usage: ${_appName} [<options>] <file.dart>\n');
   print('<file.dart> is a single Dart file to run.\n');
   print('<options> include:\n');
   print(argParser.usage);
@@ -39,6 +42,10 @@ main(List<String> args) async {
   }
 
   if (options == null || options.help) _showUsageAndExit();
+  if (options.version) {
+    print('${_appName} version ${devCompilerVersion}');
+    exit(0);
+  }
 
   if (options.inputs.length != 1) {
     stderr.writeln("Please only specify one input to run");

--- a/lib/devc.dart
+++ b/lib/devc.dart
@@ -10,3 +10,6 @@ export 'src/analysis_context.dart'
 export 'src/compiler.dart' show BatchCompiler, setupLogger, createErrorReporter;
 export 'src/server/server.dart' show DevServer;
 export 'strong_mode.dart' show StrongModeOptions;
+
+// When updating this version, also update the version in the pubspec.
+const devCompilerVersion = '0.1.7';

--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -48,7 +48,7 @@ StreamSubscription setupLogger(Level level, printFn) {
 
 CompilerOptions validateOptions(List<String> args, {bool forceOutDir: false}) {
   var options = parseOptions(args, forceOutDir: forceOutDir);
-  if (!options.help) {
+  if (!options.help && !options.version) {
     var srcOpts = options.sourceOptions;
     if (!srcOpts.useMockSdk && srcOpts.dartSdkPath == null) {
       print('Could not automatically find dart sdk path.');

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -115,6 +115,9 @@ class CompilerOptions {
   /// Whether the user asked for help.
   final bool help;
 
+  /// Whether the user asked for the app version.
+  final bool version;
+
   /// Minimum log-level reported on the command-line.
   final Level logLevel;
 
@@ -155,6 +158,7 @@ class CompilerOptions {
       this.dumpInfoFile,
       this.useColors: true,
       this.help: false,
+      this.version: false,
       this.logLevel: Level.SEVERE,
       this.serverMode: false,
       this.enableHashing: false,
@@ -170,6 +174,7 @@ class CompilerOptions {
 CompilerOptions parseOptions(List<String> argv, {bool forceOutDir: false}) {
   ArgResults args = argParser.parse(argv);
   bool showUsage = args['help'];
+  bool showVersion = args['version'];
 
   var serverMode = args['server'];
   var enableHashing = args['hashing'];
@@ -241,6 +246,7 @@ CompilerOptions parseOptions(List<String> argv, {bool forceOutDir: false}) {
       dumpInfoFile: args['dump-info-file'],
       useColors: useColors,
       help: showUsage,
+      version: showVersion,
       logLevel: logLevel,
       serverMode: serverMode,
       enableHashing: enableHashing,
@@ -288,6 +294,7 @@ final ArgParser argParser = StrongModeOptions.addArguments(new ArgParser()
 
   // general options
   ..addFlag('help', abbr: 'h', help: 'Display this message')
+  ..addFlag('version', help: 'Display the Dev Compiler verion')
   ..addFlag('server', help: 'Run as a development server.', defaultsTo: false)
   ..addFlag('hashing',
       help: 'Enable hash-based file caching.', defaultsTo: null)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,13 @@
 name: dev_compiler
+# When updating this version, also update the version in lib/devc.dart.
 version: 0.1.7
 description: >
   Experimental Dart to JavaScript compiler designed to create idiomatic,
   readable JavaScript output.
+
 author: Dart Dev Compiler team <dev-compiler@dartlang.org>
 homepage: https://github.com/dart-lang/dev_compiler
+
 dependencies:
   analyzer: ^0.26.0-alpha.0
   args: ^0.13.0
@@ -19,14 +22,17 @@ dependencies:
   source_maps: ^0.10.0
   source_span: ^1.0.2
   yaml: ^2.1.2
+
 dev_dependencies:
   # We pin a specific version to ensure everyone is formatting the code exactly
   # the same way. This is because any change in dart_style, even non-breaking
   # changes, may change the output format.
   dart_style: 0.2.0
   test: ^0.12.0
+
 environment:
   sdk: ">=1.12.0-dev.1.1 <2.0.0"
+
 executables:
   # Similar to "analyzer.dart" and its command line "dartanalyzer" we use
   # "dartdevc".


### PR DESCRIPTION
Fix https://github.com/dart-lang/dev_compiler/issues/321; add a `--version` option to the dev compiler cli. This requires updating the pubspec version and a constant in the dart code in tandem.