### PR TITLE
0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # dev_compiler changelog
 
-## unreleased
+## 0.1.10
 - added an `--html-report` option to create a file summarizing compilation
   issues
 - added a `-f` alias to the `--force-compile` command line option
+- removed many info level messages that were informational to the DDC team
 
 ## 0.1.9
 

--- a/lib/devc.dart
+++ b/lib/devc.dart
@@ -11,4 +11,4 @@ export 'src/compiler.dart' show BatchCompiler, setupLogger, createErrorReporter;
 export 'src/server/server.dart' show DevServer;
 
 // When updating this version, also update the version in the pubspec.
-const devCompilerVersion = '0.1.9';
+const devCompilerVersion = '0.1.10';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dev_compiler
 # When updating this version, also update the version in lib/devc.dart.
-version: 0.1.9
+version: 0.1.10
 description: >
   Experimental Dart to JavaScript compiler designed to create idiomatic,
   readable JavaScript output.
@@ -31,7 +31,7 @@ dev_dependencies:
   test: ^0.12.0
 
 environment:
-  sdk: ">=1.12.0-dev.1.1 <2.0.0"
+  sdk: ">=1.12.0 <2.0.0"
 
 executables:
   # Similar to "analyzer.dart" and its command line "dartanalyzer" we use


### PR DESCRIPTION
Rev the published version to more easily consume the latest (fix https://github.com/dart-lang/dev_compiler/issues/374).

@vsm @leafpetersen @jmesserly 