### PR TITLE
rev to 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dev_compiler changelog
 
+## 0.1.11
+- moved js runtime files to lib/runtime/dart (dart_runtime.js -> dart/_runtime.js)
+- bug fix to source maps
+- initial support for f-bound quantification patterns
+
 ## 0.1.10
 - added an `--html-report` option to create a file summarizing compilation
   issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dev_compiler changelog
 
 ## 0.1.11
-- moved js runtime files to lib/runtime/dart (dart_runtime.js -> dart/_runtime.js)
+- moved js runtime files to lib/runtime/dart (`dart_runtime.js` -> `dart/_runtime.js`)
 - bug fix to source maps
 - initial support for f-bound quantification patterns
 

--- a/lib/devc.dart
+++ b/lib/devc.dart
@@ -11,4 +11,4 @@ export 'src/compiler.dart' show BatchCompiler, setupLogger, createErrorReporter;
 export 'src/server/server.dart' show DevServer;
 
 // When updating this version, also update the version in the pubspec.
-const devCompilerVersion = '0.1.10';
+const devCompilerVersion = '0.1.11';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dev_compiler
 # When updating this version, also update the version in lib/devc.dart.
-version: 0.1.10
+version: 0.1.11
 description: >
   Experimental Dart to JavaScript compiler designed to create idiomatic,
   readable JavaScript output.


### PR DESCRIPTION
Rev to `0.1.11` to capture ddc changes and the changed generated file structure; fix https://github.com/dart-lang/dev_compiler/issues/382.