### PR TITLE
pretty print source maps

### DIFF
--- a/lib/src/codegen/js_printer.dart
+++ b/lib/src/codegen/js_printer.dart
@@ -4,6 +4,7 @@
 
 library dev_compiler.src.codegen.js_printer;
 
+import 'dart:convert' show JSON, JsonEncoder;
 import 'dart:io' show Directory, File, Platform, Process;
 
 import 'package:analyzer/src/generated/ast.dart';
@@ -40,10 +41,12 @@ String writeJsLibrary(JS.Program jsTree, String outputPath,
   String text;
   if (context is SourceMapPrintingContext) {
     var printer = context.printer;
-    printer.add('//# sourceMappingURL=$outFilename.map');
+    printer.add('//# sourceMappingURL=$outFilename.map\n');
     // Write output file and source map
     text = printer.text;
-    new File('$outputPath.map').writeAsStringSync(printer.map);
+    var sourceMap = JSON.decode(printer.map);
+    var sourceMapText = new JsonEncoder.withIndent('  ').convert(sourceMap);
+    new File('$outputPath.map').writeAsStringSync('$sourceMapText\n');
   } else {
     text = (context as JS.SimpleJavaScriptPrintingContext).getText();
   }

--- a/lib/src/codegen/js_printer.dart
+++ b/lib/src/codegen/js_printer.dart
@@ -46,6 +46,15 @@ String writeJsLibrary(JS.Program jsTree, String outputPath,
     text = printer.text;
     var sourceMap = JSON.decode(printer.map);
     var sourceMapText = new JsonEncoder.withIndent('  ').convert(sourceMap);
+    // Convert:
+    //   "names": [
+    //     "state",
+    //     "print"
+    //   ]
+    // to:
+    //   "names": ["state","print"]
+    sourceMapText =
+        sourceMapText.replaceAll('\n    ', '').replaceAll('\n  ]', ']');
     new File('$outputPath.map').writeAsStringSync('$sourceMapText\n');
   } else {
     text = (context as JS.SimpleJavaScriptPrintingContext).getText();


### PR DESCRIPTION
This PR:

- adds an eol to the end of the generated js files
- formats the generated source maps. This does add to their size, but not substantially I believe

You can see what the deltas look like here: https://github.com/flutter/atom-flutter-dev/pull/15

I'm not super committed to the PR - it's a P4 for the source maps to look nicer :) And there are ways to format the source maps w/ less of a size increase.