### PR TITLE
Compile the sdk with --no-destructure-named-params (#396)

### DIFF
--- a/lib/runtime/dart/_interceptors.js
+++ b/lib/runtime/dart/_interceptors.js
@@ -208,13 +208,15 @@ dart_library.library('dart/_interceptors', null, /* Imports */[
         dart.as(combine, dart.functionType(dart.dynamic, [dart.dynamic, E]));
         return _internal.IterableMixinWorkaround.fold(this, initialValue, combine);
       }
-      [dartx.firstWhere](test, {orElse = null} = {}) {
+      [dartx.firstWhere](test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         return dart.as(_internal.IterableMixinWorkaround.firstWhere(this, test, orElse), E);
       }
-      [dartx.lastWhere](test, {orElse = null} = {}) {
+      [dartx.lastWhere](test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         return dart.as(_internal.IterableMixinWorkaround.lastWhereList(this, test, orElse), E);
       }
@@ -343,7 +345,8 @@ dart_library.library('dart/_interceptors', null, /* Imports */[
       toString() {
         return collection.ListBase.listToString(this);
       }
-      [dartx.toList]({growable = true} = {}) {
+      [dartx.toList](opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let list = this.slice();
         if (!dart.notNull(growable))
           JSArray$().markFixedList(dart.as(list, core.List));
@@ -1002,7 +1005,9 @@ dart_library.library('dart/_interceptors', null, /* Imports */[
     [dartx.replaceAllMapped](from, convert) {
       return this[dartx.splitMapJoin](from, {onMatch: convert});
     }
-    [dartx.splitMapJoin](from, {onMatch = null, onNonMatch = null} = {}) {
+    [dartx.splitMapJoin](from, opts) {
+      let onMatch = opts && 'onMatch' in opts ? opts.onMatch : null;
+      let onNonMatch = opts && 'onNonMatch' in opts ? opts.onNonMatch : null;
       return dart.as(_js_helper.stringReplaceAllFuncUnchecked(this, from, onMatch, onNonMatch), core.String);
     }
     [dartx.replaceFirst](from, to, startIndex) {

--- a/lib/runtime/dart/_internal.js
+++ b/lib/runtime/dart/_internal.js
@@ -83,8 +83,9 @@ dart_library.library('dart/_internal', null, /* Imports */[
         }
         return false;
       }
-      firstWhere(test, {orElse = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let length = this.length;
         for (let i = 0; dart.notNull(i) < dart.notNull(length); i = dart.notNull(i) + 1) {
@@ -99,8 +100,9 @@ dart_library.library('dart/_internal', null, /* Imports */[
           return orElse();
         dart.throw(IterableElementError.noElement());
       }
-      lastWhere(test, {orElse = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let length = this.length;
         for (let i = dart.notNull(length) - 1; dart.notNull(i) >= 0; i = dart.notNull(i) - 1) {
@@ -216,7 +218,8 @@ dart_library.library('dart/_internal', null, /* Imports */[
         dart.as(test, dart.functionType(core.bool, [E]));
         return super.takeWhile(test);
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let result = null;
         if (dart.notNull(growable)) {
           result = core.List$(E).new();
@@ -354,7 +357,8 @@ dart_library.library('dart/_internal', null, /* Imports */[
           return new (SubListIterable$(E))(this[_iterable], this[_start], newEnd);
         }
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let start = this[_start];
         let end = this[_iterable][dartx.length];
         if (this[_endOrLength] != null && dart.notNull(this[_endOrLength]) < dart.notNull(end))
@@ -968,22 +972,25 @@ dart_library.library('dart/_internal', null, /* Imports */[
         dart.as(test, dart.functionType(core.bool, [E]));
         return false;
       }
-      firstWhere(test, {orElse = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         if (orElse != null)
           return orElse();
         dart.throw(IterableElementError.noElement());
       }
-      lastWhere(test, {orElse = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         if (orElse != null)
           return orElse();
         dart.throw(IterableElementError.noElement());
       }
-      singleWhere(test, {orElse = null} = {}) {
+      singleWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         if (orElse != null)
           return orElse();
@@ -1026,7 +1033,8 @@ dart_library.library('dart/_internal', null, /* Imports */[
         dart.as(test, dart.functionType(core.bool, [E]));
         return this;
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         return dart.notNull(growable) ? dart.list([], E) : core.List$(E).new(0);
       }
       toSet() {

--- a/lib/runtime/dart/_isolate_helper.js
+++ b/lib/runtime/dart/_isolate_helper.js
@@ -34,7 +34,8 @@ dart_library.library('dart/_isolate_helper', null, /* Imports */[
   const _id = Symbol('_id');
   const _receivePort = Symbol('_receivePort');
   class _Serializer extends core.Object {
-    _Serializer({serializeSendPorts = true} = {}) {
+    _Serializer(opts) {
+      let serializeSendPorts = opts && 'serializeSendPorts' in opts ? opts.serializeSendPorts : true;
       this.serializedObjectIds = core.Map$(dart.dynamic, core.int).identity();
       this[_serializeSendPorts] = dart.as(serializeSendPorts, core.bool);
     }
@@ -190,7 +191,8 @@ dart_library.library('dart/_isolate_helper', null, /* Imports */[
   });
   const _adjustSendPorts = Symbol('_adjustSendPorts');
   class _Deserializer extends core.Object {
-    _Deserializer({adjustSendPorts = true} = {}) {
+    _Deserializer(opts) {
+      let adjustSendPorts = opts && 'adjustSendPorts' in opts ? opts.adjustSendPorts : true;
       this.deserializedObjects = core.List.new();
       this[_adjustSendPorts] = dart.as(adjustSendPorts, core.bool);
     }
@@ -1406,7 +1408,10 @@ dart_library.library('dart/_isolate_helper', null, /* Imports */[
       this[_controller] = async.StreamController.new({onCancel: dart.bind(this, 'close'), sync: true});
       this[_rawPort].handler = dart.bind(this[_controller], 'add');
     }
-    listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+    listen(onData, opts) {
+      let onError = opts && 'onError' in opts ? opts.onError : null;
+      let onDone = opts && 'onDone' in opts ? opts.onDone : null;
+      let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
       return this[_controller].stream.listen(onData, {onError: onError, onDone: onDone, cancelOnError: cancelOnError});
     }
     close() {

--- a/lib/runtime/dart/_js_helper.js
+++ b/lib/runtime/dart/_js_helper.js
@@ -31,7 +31,8 @@ dart_library.library('dart/_js_helper', null, /* Imports */[
     constructors: () => ({Native: [Native, [core.String]]})
   });
   class JsPeerInterface extends core.Object {
-    JsPeerInterface({name = null} = {}) {
+    JsPeerInterface(opts) {
+      let name = opts && 'name' in opts ? opts.name : null;
       this.name = name;
     }
   }
@@ -78,7 +79,9 @@ dart_library.library('dart/_js_helper', null, /* Imports */[
     toString() {
       return `RegExp/${this.pattern}/`;
     }
-    JSSyntaxRegExp(source, {multiLine = false, caseSensitive = true} = {}) {
+    JSSyntaxRegExp(source, opts) {
+      let multiLine = opts && 'multiLine' in opts ? opts.multiLine : false;
+      let caseSensitive = opts && 'caseSensitive' in opts ? opts.caseSensitive : true;
       this.pattern = source;
       this[_nativeRegExp] = JSSyntaxRegExp.makeNative(source, multiLine, caseSensitive, false);
       this[_nativeGlobalRegExp] = null;

--- a/lib/runtime/dart/async.js
+++ b/lib/runtime/dart/async.js
@@ -142,8 +142,10 @@ dart_library.library('dart/async', null, /* Imports */[
       get isBroadcast() {
         return false;
       }
-      asBroadcastStream({onListen = null, onCancel = null} = {}) {
+      asBroadcastStream(opts) {
+        let onListen = opts && 'onListen' in opts ? opts.onListen : null;
         dart.as(onListen, dart.functionType(dart.void, [StreamSubscription$(T)]));
+        let onCancel = opts && 'onCancel' in opts ? opts.onCancel : null;
         dart.as(onCancel, dart.functionType(dart.void, [StreamSubscription$(T)]));
         return new (_AsBroadcastStream$(T))(this, dart.as(onListen, __CastType12), dart.as(onCancel, dart.functionType(dart.void, [StreamSubscription])));
       }
@@ -239,7 +241,8 @@ dart_library.library('dart/async', null, /* Imports */[
         }
         return controller.stream;
       }
-      handleError(onError, {test = null} = {}) {
+      handleError(onError, opts) {
+        let test = opts && 'test' in opts ? opts.test : null;
         dart.as(test, dart.functionType(core.bool, [dart.dynamic]));
         return new (_HandleErrorStream$(T))(this, onError, test);
       }
@@ -533,8 +536,9 @@ dart_library.library('dart/async', null, /* Imports */[
           }), cancelOnError: true});
         return future;
       }
-      firstWhere(test, {defaultValue = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [T]));
+        let defaultValue = opts && 'defaultValue' in opts ? opts.defaultValue : null;
         dart.as(defaultValue, dart.functionType(core.Object, []));
         let future = new _Future();
         let subscription = null;
@@ -560,8 +564,9 @@ dart_library.library('dart/async', null, /* Imports */[
           }), cancelOnError: true});
         return future;
       }
-      lastWhere(test, {defaultValue = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [T]));
+        let defaultValue = opts && 'defaultValue' in opts ? opts.defaultValue : null;
         dart.as(defaultValue, dart.functionType(core.Object, []));
         let future = new _Future();
         let result = null;
@@ -651,7 +656,8 @@ dart_library.library('dart/async', null, /* Imports */[
           }).bind(this)), cancelOnError: true});
         return future;
       }
-      timeout(timeLimit, {onTimeout = null} = {}) {
+      timeout(timeLimit, opts) {
+        let onTimeout = opts && 'onTimeout' in opts ? opts.onTimeout : null;
         dart.as(onTimeout, dart.functionType(dart.void, [EventSink]));
         let controller = null;
         let subscription = null;
@@ -764,9 +770,12 @@ dart_library.library('dart/async', null, /* Imports */[
       _StreamImpl() {
         super.Stream();
       }
-      listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+      listen(onData, opts) {
         dart.as(onData, dart.functionType(dart.void, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
+        let onDone = opts && 'onDone' in opts ? opts.onDone : null;
         dart.as(onDone, dart.functionType(dart.void, []));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
         cancelOnError = core.identical(true, cancelOnError);
         let subscription = this[_createSubscription](onData, onError, onDone, cancelOnError);
         this[_onListen](subscription);
@@ -1445,8 +1454,9 @@ dart_library.library('dart/async', null, /* Imports */[
       get done() {
         return this[_ensureDoneFuture]();
       }
-      addStream(stream, {cancelOnError = true} = {}) {
+      addStream(stream, opts) {
         dart.as(stream, Stream$(T));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : true;
         if (!dart.notNull(this[_mayAddEvent]))
           dart.throw(this[_addEventError]());
         this[_state] = dart.notNull(this[_state]) | dart.notNull(_BroadcastStreamController$()._STATE_ADDSTREAM);
@@ -1767,7 +1777,8 @@ dart_library.library('dart/async', null, /* Imports */[
   });
   let __CastType2 = __CastType2$();
   class DeferredLibrary extends core.Object {
-    DeferredLibrary(libraryName, {uri = null} = {}) {
+    DeferredLibrary(libraryName, opts) {
+      let uri = opts && 'uri' in opts ? opts.uri : null;
       this.libraryName = libraryName;
       this.uri = uri;
     }
@@ -1865,7 +1876,9 @@ dart_library.library('dart/async', null, /* Imports */[
         }));
         return dart.as(result, Future$(T));
       }
-      static wait(futures, {eagerError = false, cleanUp = null} = {}) {
+      static wait(futures, opts) {
+        let eagerError = opts && 'eagerError' in opts ? opts.eagerError : false;
+        let cleanUp = opts && 'cleanUp' in opts ? opts.cleanUp : null;
         dart.as(cleanUp, dart.functionType(dart.void, [dart.dynamic]));
         let result = new (_Future$(core.List))();
         let values = null;
@@ -2254,8 +2267,9 @@ dart_library.library('dart/async', null, /* Imports */[
           this[_state] = _Future$()._INCOMPLETE;
         }
       }
-      then(f, {onError = null} = {}) {
+      then(f, opts) {
         dart.as(f, dart.functionType(dart.dynamic, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
         let result = new (_Future$())();
         if (!dart.notNull(core.identical(result[_zone], _ROOT_ZONE))) {
           f = dart.as(result[_zone].registerUnaryCallback(f), __CastType6);
@@ -2266,7 +2280,8 @@ dart_library.library('dart/async', null, /* Imports */[
         this[_addListener](new _FutureListener.then(result, f, onError));
         return result;
       }
-      catchError(onError, {test = null} = {}) {
+      catchError(onError, opts) {
+        let test = opts && 'test' in opts ? opts.test : null;
         dart.as(test, dart.functionType(core.bool, [dart.dynamic]));
         let result = new (_Future$())();
         if (!dart.notNull(core.identical(result[_zone], _ROOT_ZONE))) {
@@ -2586,7 +2601,8 @@ dart_library.library('dart/async', null, /* Imports */[
           source = result;
         }
       }
-      timeout(timeLimit, {onTimeout = null} = {}) {
+      timeout(timeLimit, opts) {
+        let onTimeout = opts && 'onTimeout' in opts ? opts.onTimeout : null;
         dart.as(onTimeout, dart.functionType(dart.dynamic, []));
         if (dart.notNull(this[_isComplete]))
           return new (_Future$()).immediate(this);
@@ -2842,14 +2858,19 @@ dart_library.library('dart/async', null, /* Imports */[
       get isBroadcast() {
         return this[_stream].isBroadcast;
       }
-      asBroadcastStream({onListen = null, onCancel = null} = {}) {
+      asBroadcastStream(opts) {
+        let onListen = opts && 'onListen' in opts ? opts.onListen : null;
         dart.as(onListen, dart.functionType(dart.void, [StreamSubscription$(T)]));
+        let onCancel = opts && 'onCancel' in opts ? opts.onCancel : null;
         dart.as(onCancel, dart.functionType(dart.void, [StreamSubscription$(T)]));
         return this[_stream].asBroadcastStream({onListen: onListen, onCancel: onCancel});
       }
-      listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+      listen(onData, opts) {
         dart.as(onData, dart.functionType(dart.void, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
+        let onDone = opts && 'onDone' in opts ? opts.onDone : null;
         dart.as(onDone, dart.functionType(dart.void, []));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
         return this[_stream].listen(onData, {onError: onError, onDone: onDone, cancelOnError: cancelOnError});
       }
     }
@@ -2940,13 +2961,21 @@ dart_library.library('dart/async', null, /* Imports */[
   const __CastType18 = dart.typedef('__CastType18', () => dart.functionType(dart.void, [EventSink]));
   const StreamController$ = dart.generic(function(T) {
     class StreamController extends core.Object {
-      static new({onListen = null, onPause = null, onResume = null, onCancel = null, sync = false} = {}) {
+      static new(opts) {
+        let onListen = opts && 'onListen' in opts ? opts.onListen : null;
+        let onPause = opts && 'onPause' in opts ? opts.onPause : null;
+        let onResume = opts && 'onResume' in opts ? opts.onResume : null;
+        let onCancel = opts && 'onCancel' in opts ? opts.onCancel : null;
+        let sync = opts && 'sync' in opts ? opts.sync : false;
         if (onListen == null && onPause == null && onResume == null && onCancel == null) {
           return dart.as(dart.notNull(sync) ? new _NoCallbackSyncStreamController() : new _NoCallbackAsyncStreamController(), StreamController$(T));
         }
         return dart.notNull(sync) ? new (_SyncStreamController$(T))(onListen, onPause, onResume, onCancel) : new (_AsyncStreamController$(T))(onListen, onPause, onResume, onCancel);
       }
-      static broadcast({onListen = null, onCancel = null, sync = false} = {}) {
+      static broadcast(opts) {
+        let onListen = opts && 'onListen' in opts ? opts.onListen : null;
+        let onCancel = opts && 'onCancel' in opts ? opts.onCancel : null;
+        let sync = opts && 'sync' in opts ? opts.sync : false;
         return dart.notNull(sync) ? new (_SyncBroadcastStreamController$(T))(onListen, onCancel) : new (_AsyncBroadcastStreamController$(T))(onListen, onCancel);
       }
     }
@@ -3058,8 +3087,9 @@ dart_library.library('dart/async', null, /* Imports */[
         dart.assert(this[_isAddingStream]);
         return new core.StateError("Cannot add event while adding a stream");
       }
-      addStream(source, {cancelOnError = true} = {}) {
+      addStream(source, opts) {
         dart.as(source, Stream$(T));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : true;
         if (!dart.notNull(this[_mayAddEvent]))
           dart.throw(this[_badEventState]());
         if (dart.notNull(this[_isCanceled]))
@@ -3379,8 +3409,9 @@ dart_library.library('dart/async', null, /* Imports */[
       close() {
         return this[_target].close();
       }
-      addStream(source, {cancelOnError = true} = {}) {
+      addStream(source, opts) {
         dart.as(source, Stream$(T));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : true;
         return this[_target].addStream(source, {cancelOnError: cancelOnError});
       }
       get done() {
@@ -3854,9 +3885,12 @@ dart_library.library('dart/async', null, /* Imports */[
       get isBroadcast() {
         return true;
       }
-      listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+      listen(onData, opts) {
         dart.as(onData, dart.functionType(dart.void, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
+        let onDone = opts && 'onDone' in opts ? opts.onDone : null;
         dart.as(onDone, dart.functionType(dart.void, []));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
         if (this[_controller] == null || dart.notNull(this[_controller].isClosed)) {
           return new (_DoneStreamSubscription$(T))(onDone);
         }
@@ -4174,9 +4208,12 @@ dart_library.library('dart/async', null, /* Imports */[
       get isBroadcast() {
         return this[_source].isBroadcast;
       }
-      listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+      listen(onData, opts) {
         dart.as(onData, dart.functionType(dart.void, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
+        let onDone = opts && 'onDone' in opts ? opts.onDone : null;
         dart.as(onDone, dart.functionType(dart.void, []));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
         cancelOnError = core.identical(true, cancelOnError);
         return this[_createSubscription](onData, onError, onDone, cancelOnError);
       }
@@ -4765,9 +4802,12 @@ dart_library.library('dart/async', null, /* Imports */[
         this[_sinkMapper] = sinkMapper;
         super.Stream();
       }
-      listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+      listen(onData, opts) {
         dart.as(onData, dart.functionType(dart.void, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
+        let onDone = opts && 'onDone' in opts ? opts.onDone : null;
         dart.as(onDone, dart.functionType(dart.void, []));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
         cancelOnError = core.identical(true, cancelOnError);
         let subscription = new (_SinkTransformerStreamSubscription$(dart.dynamic, T))(this[_stream], dart.as(this[_sinkMapper], _SinkMapper), onData, onError, onDone, cancelOnError);
         return subscription;
@@ -4830,7 +4870,10 @@ dart_library.library('dart/async', null, /* Imports */[
   let _HandlerEventSink = _HandlerEventSink$();
   const _StreamHandlerTransformer$ = dart.generic(function(S, T) {
     class _StreamHandlerTransformer extends _StreamSinkTransformer$(S, T) {
-      _StreamHandlerTransformer({handleData = null, handleError = null, handleDone = null} = {}) {
+      _StreamHandlerTransformer(opts) {
+        let handleData = opts && 'handleData' in opts ? opts.handleData : null;
+        let handleError = opts && 'handleError' in opts ? opts.handleError : null;
+        let handleDone = opts && 'handleDone' in opts ? opts.handleDone : null;
         super._StreamSinkTransformer(dart.as(dart.fn(outputSink => {
           dart.as(outputSink, EventSink$(T));
           if (handleData == null)
@@ -4900,9 +4943,12 @@ dart_library.library('dart/async', null, /* Imports */[
         this[_transformer] = transformer;
         super.Stream();
       }
-      listen(onData, {onError = null, onDone = null, cancelOnError = null} = {}) {
+      listen(onData, opts) {
         dart.as(onData, dart.functionType(dart.void, [T]));
+        let onError = opts && 'onError' in opts ? opts.onError : null;
+        let onDone = opts && 'onDone' in opts ? opts.onDone : null;
         dart.as(onDone, dart.functionType(dart.void, []));
+        let cancelOnError = opts && 'cancelOnError' in opts ? opts.cancelOnError : null;
         cancelOnError = core.identical(true, cancelOnError);
         let result = this[_transformer](this[_stream], cancelOnError);
         result.onData(onData);
@@ -4999,7 +5045,20 @@ dart_library.library('dart/async', null, /* Imports */[
     static new(opts) {
       return new _ZoneSpecification(opts);
     }
-    static from(other, {handleUncaughtError = null, run = null, runUnary = null, runBinary = null, registerCallback = null, registerUnaryCallback = null, registerBinaryCallback = null, errorCallback = null, scheduleMicrotask = null, createTimer = null, createPeriodicTimer = null, print = null, fork = null} = {}) {
+    static from(other, opts) {
+      let handleUncaughtError = opts && 'handleUncaughtError' in opts ? opts.handleUncaughtError : null;
+      let run = opts && 'run' in opts ? opts.run : null;
+      let runUnary = opts && 'runUnary' in opts ? opts.runUnary : null;
+      let runBinary = opts && 'runBinary' in opts ? opts.runBinary : null;
+      let registerCallback = opts && 'registerCallback' in opts ? opts.registerCallback : null;
+      let registerUnaryCallback = opts && 'registerUnaryCallback' in opts ? opts.registerUnaryCallback : null;
+      let registerBinaryCallback = opts && 'registerBinaryCallback' in opts ? opts.registerBinaryCallback : null;
+      let errorCallback = opts && 'errorCallback' in opts ? opts.errorCallback : null;
+      let scheduleMicrotask = opts && 'scheduleMicrotask' in opts ? opts.scheduleMicrotask : null;
+      let createTimer = opts && 'createTimer' in opts ? opts.createTimer : null;
+      let createPeriodicTimer = opts && 'createPeriodicTimer' in opts ? opts.createPeriodicTimer : null;
+      let print = opts && 'print' in opts ? opts.print : null;
+      let fork = opts && 'fork' in opts ? opts.fork : null;
       return ZoneSpecification.new({handleUncaughtError: handleUncaughtError != null ? handleUncaughtError : other.handleUncaughtError, run: run != null ? run : other.run, runUnary: runUnary != null ? runUnary : other.runUnary, runBinary: runBinary != null ? runBinary : other.runBinary, registerCallback: registerCallback != null ? registerCallback : other.registerCallback, registerUnaryCallback: registerUnaryCallback != null ? registerUnaryCallback : other.registerUnaryCallback, registerBinaryCallback: registerBinaryCallback != null ? registerBinaryCallback : other.registerBinaryCallback, errorCallback: errorCallback != null ? errorCallback : other.errorCallback, scheduleMicrotask: scheduleMicrotask != null ? scheduleMicrotask : other.scheduleMicrotask, createTimer: createTimer != null ? createTimer : other.createTimer, createPeriodicTimer: createPeriodicTimer != null ? createPeriodicTimer : other.createPeriodicTimer, print: print != null ? print : other.print, fork: fork != null ? fork : other.fork});
     }
   }
@@ -5010,7 +5069,20 @@ dart_library.library('dart/async', null, /* Imports */[
     })
   });
   class _ZoneSpecification extends core.Object {
-    _ZoneSpecification({handleUncaughtError = null, run = null, runUnary = null, runBinary = null, registerCallback = null, registerUnaryCallback = null, registerBinaryCallback = null, errorCallback = null, scheduleMicrotask = null, createTimer = null, createPeriodicTimer = null, print = null, fork = null} = {}) {
+    _ZoneSpecification(opts) {
+      let handleUncaughtError = opts && 'handleUncaughtError' in opts ? opts.handleUncaughtError : null;
+      let run = opts && 'run' in opts ? opts.run : null;
+      let runUnary = opts && 'runUnary' in opts ? opts.runUnary : null;
+      let runBinary = opts && 'runBinary' in opts ? opts.runBinary : null;
+      let registerCallback = opts && 'registerCallback' in opts ? opts.registerCallback : null;
+      let registerUnaryCallback = opts && 'registerUnaryCallback' in opts ? opts.registerUnaryCallback : null;
+      let registerBinaryCallback = opts && 'registerBinaryCallback' in opts ? opts.registerBinaryCallback : null;
+      let errorCallback = opts && 'errorCallback' in opts ? opts.errorCallback : null;
+      let scheduleMicrotask = opts && 'scheduleMicrotask' in opts ? opts.scheduleMicrotask : null;
+      let createTimer = opts && 'createTimer' in opts ? opts.createTimer : null;
+      let createPeriodicTimer = opts && 'createPeriodicTimer' in opts ? opts.createPeriodicTimer : null;
+      let print = opts && 'print' in opts ? opts.print : null;
+      let fork = opts && 'fork' in opts ? opts.fork : null;
       this.handleUncaughtError = handleUncaughtError;
       this.run = run;
       this.runUnary = runUnary;
@@ -5178,21 +5250,24 @@ dart_library.library('dart/async', null, /* Imports */[
       }
 
     }
-    bindCallback(f, {runGuarded = true} = {}) {
+    bindCallback(f, opts) {
+      let runGuarded = opts && 'runGuarded' in opts ? opts.runGuarded : true;
       if (dart.notNull(runGuarded)) {
         return dart.fn((() => this.runGuarded(f)).bind(this));
       } else {
         return dart.fn((() => this.run(f)).bind(this));
       }
     }
-    bindUnaryCallback(f, {runGuarded = true} = {}) {
+    bindUnaryCallback(f, opts) {
+      let runGuarded = opts && 'runGuarded' in opts ? opts.runGuarded : true;
       if (dart.notNull(runGuarded)) {
         return dart.fn((arg => this.runUnaryGuarded(f, arg)).bind(this));
       } else {
         return dart.fn((arg => this.runUnary(f, arg)).bind(this));
       }
     }
-    bindBinaryCallback(f, {runGuarded = true} = {}) {
+    bindBinaryCallback(f, opts) {
+      let runGuarded = opts && 'runGuarded' in opts ? opts.runGuarded : true;
       if (dart.notNull(runGuarded)) {
         return dart.fn(((arg1, arg2) => this.runBinaryGuarded(f, arg1, arg2)).bind(this));
       } else {
@@ -5205,7 +5280,9 @@ dart_library.library('dart/async', null, /* Imports */[
     handleUncaughtError(error, stackTrace) {
       return _rootHandleUncaughtError(null, null, this, error, stackTrace);
     }
-    fork({specification = null, zoneValues = null} = {}) {
+    fork(opts) {
+      let specification = opts && 'specification' in opts ? opts.specification : null;
+      let zoneValues = opts && 'zoneValues' in opts ? opts.zoneValues : null;
       return _rootFork(null, null, this, specification, zoneValues);
     }
     run(f) {
@@ -5444,7 +5521,8 @@ dart_library.library('dart/async', null, /* Imports */[
       }
 
     }
-    bindCallback(f, {runGuarded = true} = {}) {
+    bindCallback(f, opts) {
+      let runGuarded = opts && 'runGuarded' in opts ? opts.runGuarded : true;
       let registered = this.registerCallback(f);
       if (dart.notNull(runGuarded)) {
         return dart.fn((() => this.runGuarded(registered)).bind(this));
@@ -5452,7 +5530,8 @@ dart_library.library('dart/async', null, /* Imports */[
         return dart.fn((() => this.run(registered)).bind(this));
       }
     }
-    bindUnaryCallback(f, {runGuarded = true} = {}) {
+    bindUnaryCallback(f, opts) {
+      let runGuarded = opts && 'runGuarded' in opts ? opts.runGuarded : true;
       let registered = this.registerUnaryCallback(f);
       if (dart.notNull(runGuarded)) {
         return dart.fn((arg => this.runUnaryGuarded(registered, arg)).bind(this));
@@ -5460,7 +5539,8 @@ dart_library.library('dart/async', null, /* Imports */[
         return dart.fn((arg => this.runUnary(registered, arg)).bind(this));
       }
     }
-    bindBinaryCallback(f, {runGuarded = true} = {}) {
+    bindBinaryCallback(f, opts) {
+      let runGuarded = opts && 'runGuarded' in opts ? opts.runGuarded : true;
       let registered = this.registerBinaryCallback(f);
       if (dart.notNull(runGuarded)) {
         return dart.fn(((arg1, arg2) => this.runBinaryGuarded(registered, arg1, arg2)).bind(this));
@@ -5488,7 +5568,9 @@ dart_library.library('dart/async', null, /* Imports */[
       let parentDelegate = _parentDelegate(implementation.zone);
       return dart.dcall(implementation.function, implementation.zone, parentDelegate, this, error, stackTrace);
     }
-    fork({specification = null, zoneValues = null} = {}) {
+    fork(opts) {
+      let specification = opts && 'specification' in opts ? opts.specification : null;
+      let zoneValues = opts && 'zoneValues' in opts ? opts.zoneValues : null;
       let implementation = this[_fork];
       dart.assert(implementation != null);
       let parentDelegate = _parentDelegate(implementation.zone);
@@ -5743,7 +5825,10 @@ dart_library.library('dart/async', null, /* Imports */[
     },
     set _rootMap(_) {}
   });
-  function runZoned(body, {zoneValues = null, zoneSpecification = null, onError = null} = {}) {
+  function runZoned(body, opts) {
+    let zoneValues = opts && 'zoneValues' in opts ? opts.zoneValues : null;
+    let zoneSpecification = opts && 'zoneSpecification' in opts ? opts.zoneSpecification : null;
+    let onError = opts && 'onError' in opts ? opts.onError : null;
     let errorHandler = null;
     if (onError != null) {
       errorHandler = dart.fn((self, parent, zone, error, stackTrace) => {

--- a/lib/runtime/dart/collection.js
+++ b/lib/runtime/dart/collection.js
@@ -49,7 +49,10 @@ dart_library.library('dart/collection', null, /* Imports */[
   let _Hasher = _Hasher$();
   const HashMap$ = dart.generic(function(K, V) {
     class HashMap extends core.Object {
-      static new({equals = null, hashCode = null, isValidKey = null} = {}) {
+      static new(opts) {
+        let equals = opts && 'equals' in opts ? opts.equals : null;
+        let hashCode = opts && 'hashCode' in opts ? opts.hashCode : null;
+        let isValidKey = opts && 'isValidKey' in opts ? opts.isValidKey : null;
         if (isValidKey == null) {
           if (hashCode == null) {
             if (equals == null) {
@@ -84,7 +87,9 @@ dart_library.library('dart/collection', null, /* Imports */[
         }));
         return result;
       }
-      static fromIterable(iterable, {key = null, value = null} = {}) {
+      static fromIterable(iterable, opts) {
+        let key = opts && 'key' in opts ? opts.key : null;
+        let value = opts && 'value' in opts ? opts.value : null;
         let map = HashMap$(K, V).new();
         Maps._fillMapWithMappedIterable(map, iterable, key, value);
         return map;
@@ -185,7 +190,8 @@ dart_library.library('dart/collection', null, /* Imports */[
         }
         return result;
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let result = dart.notNull(growable) ? (() => {
           let _ = core.List$(E).new();
           _[dartx.length] = this.length;
@@ -316,8 +322,9 @@ dart_library.library('dart/collection', null, /* Imports */[
         } while (dart.notNull(it.moveNext()));
         return result;
       }
-      firstWhere(test, {orElse = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         for (let element of this) {
           if (dart.notNull(test(element)))
@@ -327,8 +334,9 @@ dart_library.library('dart/collection', null, /* Imports */[
           return orElse();
         dart.throw(_internal.IterableElementError.noElement());
       }
-      lastWhere(test, {orElse = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let result = null;
         let foundMatching = false;
@@ -488,7 +496,10 @@ dart_library.library('dart/collection', null, /* Imports */[
   let _HashSetBase = _HashSetBase$();
   const HashSet$ = dart.generic(function(E) {
     class HashSet extends core.Object {
-      static new({equals = null, hashCode = null, isValidKey = null} = {}) {
+      static new(opts) {
+        let equals = opts && 'equals' in opts ? opts.equals : null;
+        let hashCode = opts && 'hashCode' in opts ? opts.hashCode : null;
+        let isValidKey = opts && 'isValidKey' in opts ? opts.isValidKey : null;
         if (isValidKey == null) {
           if (hashCode == null) {
             if (equals == null) {
@@ -618,7 +629,8 @@ dart_library.library('dart/collection', null, /* Imports */[
         }
         return false;
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         return core.List$(E).from(this, {growable: growable});
       }
       toSet() {
@@ -680,8 +692,9 @@ dart_library.library('dart/collection', null, /* Imports */[
           dart.throw(_internal.IterableElementError.tooMany());
         return result;
       }
-      firstWhere(test, {orElse = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         for (let element of this) {
           if (dart.notNull(test(element)))
@@ -691,8 +704,9 @@ dart_library.library('dart/collection', null, /* Imports */[
           return orElse();
         dart.throw(_internal.IterableElementError.noElement());
       }
-      lastWhere(test, {orElse = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let result = null;
         let foundMatching = false;
@@ -883,7 +897,8 @@ dart_library.library('dart/collection', null, /* Imports */[
         }
         return false;
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         return core.List$(E).from(this, {growable: growable});
       }
       toSet() {
@@ -945,8 +960,9 @@ dart_library.library('dart/collection', null, /* Imports */[
           dart.throw(_internal.IterableElementError.tooMany());
         return result;
       }
-      firstWhere(test, {orElse = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         for (let element of this) {
           if (dart.notNull(test(element)))
@@ -956,8 +972,9 @@ dart_library.library('dart/collection', null, /* Imports */[
           return orElse();
         dart.throw(_internal.IterableElementError.noElement());
       }
-      lastWhere(test, {orElse = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let result = null;
         let foundMatching = false;
@@ -1253,7 +1270,10 @@ dart_library.library('dart/collection', null, /* Imports */[
   HasNextIterator._NOT_MOVED_YET = 2;
   const LinkedHashMap$ = dart.generic(function(K, V) {
     class LinkedHashMap extends core.Object {
-      static new({equals = null, hashCode = null, isValidKey = null} = {}) {
+      static new(opts) {
+        let equals = opts && 'equals' in opts ? opts.equals : null;
+        let hashCode = opts && 'hashCode' in opts ? opts.hashCode : null;
+        let isValidKey = opts && 'isValidKey' in opts ? opts.isValidKey : null;
         if (isValidKey == null) {
           if (hashCode == null) {
             if (equals == null) {
@@ -1288,7 +1308,9 @@ dart_library.library('dart/collection', null, /* Imports */[
         }));
         return result;
       }
-      static fromIterable(iterable, {key = null, value = null} = {}) {
+      static fromIterable(iterable, opts) {
+        let key = opts && 'key' in opts ? opts.key : null;
+        let value = opts && 'value' in opts ? opts.value : null;
         let map = LinkedHashMap$(K, V).new();
         Maps._fillMapWithMappedIterable(map, iterable, key, value);
         return map;
@@ -1322,7 +1344,10 @@ dart_library.library('dart/collection', null, /* Imports */[
   let LinkedHashMap = LinkedHashMap$();
   const LinkedHashSet$ = dart.generic(function(E) {
     class LinkedHashSet extends core.Object {
-      static new({equals = null, hashCode = null, isValidKey = null} = {}) {
+      static new(opts) {
+        let equals = opts && 'equals' in opts ? opts.equals : null;
+        let hashCode = opts && 'hashCode' in opts ? opts.hashCode : null;
+        let isValidKey = opts && 'isValidKey' in opts ? opts.isValidKey : null;
         if (isValidKey == null) {
           if (hashCode == null) {
             if (equals == null) {
@@ -1673,8 +1698,9 @@ dart_library.library('dart/collection', null, /* Imports */[
         }
         return false;
       }
-      firstWhere(test, {orElse = null} = {}) {
+      firstWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let length = this.length;
         for (let i = 0; dart.notNull(i) < dart.notNull(length); i = dart.notNull(i) + 1) {
@@ -1689,8 +1715,9 @@ dart_library.library('dart/collection', null, /* Imports */[
           return orElse();
         dart.throw(_internal.IterableElementError.noElement());
       }
-      lastWhere(test, {orElse = null} = {}) {
+      lastWhere(test, opts) {
         dart.as(test, dart.functionType(core.bool, [E]));
+        let orElse = opts && 'orElse' in opts ? opts.orElse : null;
         dart.as(orElse, dart.functionType(E, []));
         let length = this.length;
         for (let i = dart.notNull(length) - 1; dart.notNull(i) >= 0; i = dart.notNull(i) - 1) {
@@ -1788,7 +1815,8 @@ dart_library.library('dart/collection', null, /* Imports */[
         dart.as(test, dart.functionType(core.bool, [E]));
         return new (_internal.TakeWhileIterable$(E))(this, test);
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let result = null;
         if (dart.notNull(growable)) {
           result = core.List$(E).new();
@@ -2972,7 +3000,8 @@ dart_library.library('dart/collection', null, /* Imports */[
         core.RangeError.checkValidIndex(index, this);
         return this[_table][dartx.get](dart.notNull(this[_head]) + dart.notNull(index) & dart.notNull(this[_table][dartx.length]) - 1);
       }
-      toList({growable = true} = {}) {
+      toList(opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let list = null;
         if (dart.notNull(growable)) {
           list = core.List$(E).new();
@@ -3483,7 +3512,11 @@ dart_library.library('dart/collection', null, /* Imports */[
         }));
         return result;
       }
-      static fromIterable(iterable, {key = null, value = null, compare = null, isValidKey = null} = {}) {
+      static fromIterable(iterable, opts) {
+        let key = opts && 'key' in opts ? opts.key : null;
+        let value = opts && 'value' in opts ? opts.value : null;
+        let compare = opts && 'compare' in opts ? opts.compare : null;
+        let isValidKey = opts && 'isValidKey' in opts ? opts.isValidKey : null;
         let map = new (SplayTreeMap$(K, V))(compare, isValidKey);
         Maps._fillMapWithMappedIterable(map, iterable, key, value);
         return map;

--- a/lib/runtime/dart/convert.js
+++ b/lib/runtime/dart/convert.js
@@ -65,14 +65,16 @@ dart_library.library('dart/convert', null, /* Imports */[
   });
   const _allowInvalid = Symbol('_allowInvalid');
   class AsciiCodec extends Encoding {
-    AsciiCodec({allowInvalid = false} = {}) {
+    AsciiCodec(opts) {
+      let allowInvalid = opts && 'allowInvalid' in opts ? opts.allowInvalid : false;
       this[_allowInvalid] = allowInvalid;
       super.Encoding();
     }
     get name() {
       return "us-ascii";
     }
-    decode(bytes, {allowInvalid = null} = {}) {
+    decode(bytes, opts) {
+      let allowInvalid = opts && 'allowInvalid' in opts ? opts.allowInvalid : null;
       if (allowInvalid == null)
         allowInvalid = this[_allowInvalid];
       if (dart.notNull(allowInvalid)) {
@@ -276,7 +278,8 @@ dart_library.library('dart/convert', null, /* Imports */[
     })
   });
   class AsciiDecoder extends _UnicodeSubsetDecoder {
-    AsciiDecoder({allowInvalid = false} = {}) {
+    AsciiDecoder(opts) {
+      let allowInvalid = opts && 'allowInvalid' in opts ? opts.allowInvalid : false;
       super._UnicodeSubsetDecoder(allowInvalid, _ASCII_MASK);
     }
     startChunkedConversion(sink) {
@@ -778,7 +781,8 @@ dart_library.library('dart/convert', null, /* Imports */[
     })
   });
   class JsonUnsupportedObjectError extends core.Error {
-    JsonUnsupportedObjectError(unsupportedObject, {cause = null} = {}) {
+    JsonUnsupportedObjectError(unsupportedObject, opts) {
+      let cause = opts && 'cause' in opts ? opts.cause : null;
       this.unsupportedObject = unsupportedObject;
       this.cause = cause;
       super.Error();
@@ -808,7 +812,9 @@ dart_library.library('dart/convert', null, /* Imports */[
   const _reviver = Symbol('_reviver');
   const _toEncodable$ = Symbol('_toEncodable');
   class JsonCodec extends Codec$(core.Object, core.String) {
-    JsonCodec({reviver = null, toEncodable = null} = {}) {
+    JsonCodec(opts) {
+      let reviver = opts && 'reviver' in opts ? opts.reviver : null;
+      let toEncodable = opts && 'toEncodable' in opts ? opts.toEncodable : null;
       this[_reviver] = reviver;
       this[_toEncodable$] = toEncodable;
       super.Codec();
@@ -816,14 +822,16 @@ dart_library.library('dart/convert', null, /* Imports */[
     withReviver(reviver) {
       this.JsonCodec({reviver: reviver});
     }
-    decode(source, {reviver = null} = {}) {
+    decode(source, opts) {
+      let reviver = opts && 'reviver' in opts ? opts.reviver : null;
       if (reviver == null)
         reviver = this[_reviver];
       if (reviver == null)
         return this.decoder.convert(source);
       return new JsonDecoder(reviver).convert(source);
     }
-    encode(value, {toEncodable = null} = {}) {
+    encode(value, opts) {
+      let toEncodable = opts && 'toEncodable' in opts ? opts.toEncodable : null;
       if (toEncodable == null)
         toEncodable = this[_toEncodable$];
       if (toEncodable == null)
@@ -1552,14 +1560,16 @@ dart_library.library('dart/convert', null, /* Imports */[
   const __CastType2 = dart.typedef('__CastType2', () => dart.functionType(dart.dynamic, [dart.dynamic]));
   const __CastType4 = dart.typedef('__CastType4', () => dart.functionType(dart.dynamic, [core.Object]));
   class Latin1Codec extends Encoding {
-    Latin1Codec({allowInvalid = false} = {}) {
+    Latin1Codec(opts) {
+      let allowInvalid = opts && 'allowInvalid' in opts ? opts.allowInvalid : false;
       this[_allowInvalid] = allowInvalid;
       super.Encoding();
     }
     get name() {
       return "iso-8859-1";
     }
-    decode(bytes, {allowInvalid = null} = {}) {
+    decode(bytes, opts) {
+      let allowInvalid = opts && 'allowInvalid' in opts ? opts.allowInvalid : null;
       if (allowInvalid == null)
         allowInvalid = this[_allowInvalid];
       if (dart.notNull(allowInvalid)) {
@@ -1590,7 +1600,8 @@ dart_library.library('dart/convert', null, /* Imports */[
     constructors: () => ({Latin1Encoder: [Latin1Encoder, []]})
   });
   class Latin1Decoder extends _UnicodeSubsetDecoder {
-    Latin1Decoder({allowInvalid = false} = {}) {
+    Latin1Decoder(opts) {
+      let allowInvalid = opts && 'allowInvalid' in opts ? opts.allowInvalid : false;
       super._UnicodeSubsetDecoder(allowInvalid, _LATIN1_MASK);
     }
     startChunkedConversion(sink) {
@@ -2058,14 +2069,16 @@ dart_library.library('dart/convert', null, /* Imports */[
   const UNICODE_BOM_CHARACTER_RUNE = 65279;
   const _allowMalformed = Symbol('_allowMalformed');
   class Utf8Codec extends Encoding {
-    Utf8Codec({allowMalformed = false} = {}) {
+    Utf8Codec(opts) {
+      let allowMalformed = opts && 'allowMalformed' in opts ? opts.allowMalformed : false;
       this[_allowMalformed] = allowMalformed;
       super.Encoding();
     }
     get name() {
       return "utf-8";
     }
-    decode(codeUnits, {allowMalformed = null} = {}) {
+    decode(codeUnits, opts) {
+      let allowMalformed = opts && 'allowMalformed' in opts ? opts.allowMalformed : null;
       if (allowMalformed == null)
         allowMalformed = this[_allowMalformed];
       return new Utf8Decoder({allowMalformed: allowMalformed}).convert(codeUnits);
@@ -2321,7 +2334,8 @@ dart_library.library('dart/convert', null, /* Imports */[
     })
   });
   class Utf8Decoder extends Converter$(core.List$(core.int), core.String) {
-    Utf8Decoder({allowMalformed = false} = {}) {
+    Utf8Decoder(opts) {
+      let allowMalformed = opts && 'allowMalformed' in opts ? opts.allowMalformed : false;
       this[_allowMalformed] = allowMalformed;
       super.Converter();
     }

--- a/lib/runtime/dart/core.js
+++ b/lib/runtime/dart/core.js
@@ -73,7 +73,8 @@ dart_library.library('dart/core', null, /* Imports */[
     'toString'
   ]);
   class bool extends Object {
-    static fromEnvironment(name, {defaultValue = false} = {}) {
+    static fromEnvironment(name, opts) {
+      let defaultValue = opts && 'defaultValue' in opts ? opts.defaultValue : false;
       dart.throw(new UnsupportedError('bool.fromEnvironment can only be used as a const constructor'));
     }
     toString() {
@@ -186,7 +187,8 @@ dart_library.library('dart/core', null, /* Imports */[
         dart.throw(new FormatException("Invalid date format", formattedString));
       }
     }
-    fromMillisecondsSinceEpoch(millisecondsSinceEpoch, {isUtc = false} = {}) {
+    fromMillisecondsSinceEpoch(millisecondsSinceEpoch, opts) {
+      let isUtc = opts && 'isUtc' in opts ? opts.isUtc : false;
       this.millisecondsSinceEpoch = millisecondsSinceEpoch;
       this.isUtc = isUtc;
       if (dart.notNull(millisecondsSinceEpoch[dartx.abs]()) > dart.notNull(DateTime._MAX_MILLISECONDS_SINCE_EPOCH)) {
@@ -457,7 +459,13 @@ dart_library.library('dart/core', null, /* Imports */[
   double.MAX_FINITE = 1.7976931348623157e+308;
   const _duration = dart.JsSymbol('_duration');
   class Duration extends Object {
-    Duration({days = 0, hours = 0, minutes = 0, seconds = 0, milliseconds = 0, microseconds = 0} = {}) {
+    Duration(opts) {
+      let days = opts && 'days' in opts ? opts.days : 0;
+      let hours = opts && 'hours' in opts ? opts.hours : 0;
+      let minutes = opts && 'minutes' in opts ? opts.minutes : 0;
+      let seconds = opts && 'seconds' in opts ? opts.seconds : 0;
+      let milliseconds = opts && 'milliseconds' in opts ? opts.milliseconds : 0;
+      let microseconds = opts && 'microseconds' in opts ? opts.microseconds : 0;
       this._microseconds(dart.notNull(days) * dart.notNull(Duration.MICROSECONDS_PER_DAY) + dart.notNull(hours) * dart.notNull(Duration.MICROSECONDS_PER_HOUR) + dart.notNull(minutes) * dart.notNull(Duration.MICROSECONDS_PER_MINUTE) + dart.notNull(seconds) * dart.notNull(Duration.MICROSECONDS_PER_SECOND) + dart.notNull(milliseconds) * dart.notNull(Duration.MICROSECONDS_PER_MILLISECOND) + dart.notNull(microseconds));
     }
     _microseconds(duration) {
@@ -1230,10 +1238,13 @@ dart_library.library('dart/core', null, /* Imports */[
   }
   dart.fn(identityHashCode, () => dart.definiteFunctionType(int, [Object]));
   class int extends num {
-    static fromEnvironment(name, {defaultValue = null} = {}) {
+    static fromEnvironment(name, opts) {
+      let defaultValue = opts && 'defaultValue' in opts ? opts.defaultValue : null;
       dart.throw(new UnsupportedError('int.fromEnvironment can only be used as a const constructor'));
     }
-    static parse(source, {radix = null, onError = null} = {}) {
+    static parse(source, opts) {
+      let radix = opts && 'radix' in opts ? opts.radix : null;
+      let onError = opts && 'onError' in opts ? opts.onError : null;
       return _js_helper.Primitives.parseInt(source, radix, onError);
     }
   }
@@ -1418,7 +1429,8 @@ dart_library.library('dart/core', null, /* Imports */[
         }
         return result;
       }
-      static from(elements, {growable = true} = {}) {
+      static from(elements, opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let list = List$(E).new();
         for (let e of elements) {
           list[dartx.add](dart.as(e, E));
@@ -1427,7 +1439,8 @@ dart_library.library('dart/core', null, /* Imports */[
           return list;
         return dart.as(_internal.makeListFixedLength(list), List$(E));
       }
-      static generate(length, generator, {growable = true} = {}) {
+      static generate(length, generator, opts) {
+        let growable = opts && 'growable' in opts ? opts.growable : true;
         let result = null;
         if (dart.notNull(growable)) {
           result = dart.list([], E);
@@ -1510,7 +1523,9 @@ dart_library.library('dart/core', null, /* Imports */[
   dart.fn(print, dart.void, [Object]);
   class Match extends Object {}
   class RegExp extends Object {
-    static new(source, {multiLine = false, caseSensitive = true} = {}) {
+    static new(source, opts) {
+      let multiLine = opts && 'multiLine' in opts ? opts.multiLine : false;
+      let caseSensitive = opts && 'caseSensitive' in opts ? opts.caseSensitive : true;
       return new _js_helper.JSSyntaxRegExp(source, {multiLine: multiLine, caseSensitive: caseSensitive});
     }
   }
@@ -1647,7 +1662,8 @@ dart_library.library('dart/core', null, /* Imports */[
     static fromCharCode(charCode) {
       return _js_helper.Primitives.stringFromCharCode(charCode);
     }
-    static fromEnvironment(name, {defaultValue = null} = {}) {
+    static fromEnvironment(name, opts) {
+      let defaultValue = opts && 'defaultValue' in opts ? opts.defaultValue : null;
       dart.throw(new UnsupportedError('String.fromEnvironment can only be used as a const constructor'));
     }
     static _stringFromIterable(charCodes, start, end) {
@@ -2151,7 +2167,16 @@ dart_library.library('dart/core', null, /* Imports */[
       this[_pathSegments] = null;
       this[_queryParameters] = null;
     }
-    static new({scheme = "", userInfo = "", host = null, port = null, path = null, pathSegments = null, query = null, queryParameters = null, fragment = null} = {}) {
+    static new(opts) {
+      let scheme = opts && 'scheme' in opts ? opts.scheme : "";
+      let userInfo = opts && 'userInfo' in opts ? opts.userInfo : "";
+      let host = opts && 'host' in opts ? opts.host : null;
+      let port = opts && 'port' in opts ? opts.port : null;
+      let path = opts && 'path' in opts ? opts.path : null;
+      let pathSegments = opts && 'pathSegments' in opts ? opts.pathSegments : null;
+      let query = opts && 'query' in opts ? opts.query : null;
+      let queryParameters = opts && 'queryParameters' in opts ? opts.queryParameters : null;
+      let fragment = opts && 'fragment' in opts ? opts.fragment : null;
       scheme = Uri._makeScheme(scheme, Uri._stringOrNullLength(scheme));
       userInfo = Uri._makeUserInfo(userInfo, 0, Uri._stringOrNullLength(userInfo));
       host = Uri._makeHost(host, 0, Uri._stringOrNullLength(host), false);
@@ -2221,7 +2246,8 @@ dart_library.library('dart/core', null, /* Imports */[
       }
       return Uri.new({scheme: scheme, userInfo: userInfo, host: dart.as(host, String), port: dart.as(port, int), pathSegments: unencodedPath[dartx.split]("/"), queryParameters: queryParameters});
     }
-    static file(path, {windows = null} = {}) {
+    static file(path, opts) {
+      let windows = opts && 'windows' in opts ? opts.windows : null;
       windows = windows == null ? Uri._isWindows : windows;
       return dart.notNull(windows) ? dart.as(Uri._makeWindowsFileUrl(path), Uri) : dart.as(Uri._makeFileUri(path), Uri);
     }
@@ -2318,7 +2344,16 @@ dart_library.library('dart/core', null, /* Imports */[
         return Uri.new({pathSegments: pathSegments});
       }
     }
-    replace({scheme = null, userInfo = null, host = null, port = null, path = null, pathSegments = null, query = null, queryParameters = null, fragment = null} = {}) {
+    replace(opts) {
+      let scheme = opts && 'scheme' in opts ? opts.scheme : null;
+      let userInfo = opts && 'userInfo' in opts ? opts.userInfo : null;
+      let host = opts && 'host' in opts ? opts.host : null;
+      let port = opts && 'port' in opts ? opts.port : null;
+      let path = opts && 'path' in opts ? opts.path : null;
+      let pathSegments = opts && 'pathSegments' in opts ? opts.pathSegments : null;
+      let query = opts && 'query' in opts ? opts.query : null;
+      let queryParameters = opts && 'queryParameters' in opts ? opts.queryParameters : null;
+      let fragment = opts && 'fragment' in opts ? opts.fragment : null;
       let schemeChanged = false;
       if (scheme != null) {
         scheme = Uri._makeScheme(scheme, scheme[dartx.length]);
@@ -2825,7 +2860,8 @@ dart_library.library('dart/core', null, /* Imports */[
         return `${this.scheme}://${this[_host]}`;
       return `${this.scheme}://${this[_host]}:${this[_port]}`;
     }
-    toFilePath({windows = null} = {}) {
+    toFilePath(opts) {
+      let windows = opts && 'windows' in opts ? opts.windows : null;
       if (this.scheme != "" && this.scheme != "file") {
         dart.throw(new UnsupportedError(`Cannot extract a file path from a ${this.scheme} URI`));
       }
@@ -2930,13 +2966,15 @@ dart_library.library('dart/core', null, /* Imports */[
     static encodeComponent(component) {
       return Uri._uriEncode(dart.as(Uri._unreserved2396Table, List$(int)), component);
     }
-    static encodeQueryComponent(component, {encoding = convert.UTF8} = {}) {
+    static encodeQueryComponent(component, opts) {
+      let encoding = opts && 'encoding' in opts ? opts.encoding : convert.UTF8;
       return Uri._uriEncode(dart.as(Uri._unreservedTable, List$(int)), component, {encoding: encoding, spaceToPlus: true});
     }
     static decodeComponent(encodedComponent) {
       return Uri._uriDecode(encodedComponent);
     }
-    static decodeQueryComponent(encodedComponent, {encoding = convert.UTF8} = {}) {
+    static decodeQueryComponent(encodedComponent, opts) {
+      let encoding = opts && 'encoding' in opts ? opts.encoding : convert.UTF8;
       return Uri._uriDecode(encodedComponent, {plusToSpace: true, encoding: encoding});
     }
     static encodeFull(uri) {
@@ -2945,7 +2983,8 @@ dart_library.library('dart/core', null, /* Imports */[
     static decodeFull(uri) {
       return Uri._uriDecode(uri);
     }
-    static splitQueryString(query, {encoding = convert.UTF8} = {}) {
+    static splitQueryString(query, opts) {
+      let encoding = opts && 'encoding' in opts ? opts.encoding : convert.UTF8;
       return dart.as(query[dartx.split]("&")[dartx.fold](dart.map(), dart.fn((map, element) => {
         let index = dart.as(dart.dsend(element, 'indexOf', "="), int);
         if (index == -1) {
@@ -3074,7 +3113,9 @@ dart_library.library('dart/core', null, /* Imports */[
       }
       return dart.as(bytes, List$(int));
     }
-    static _uriEncode(canonicalTable, text, {encoding = convert.UTF8, spaceToPlus = false} = {}) {
+    static _uriEncode(canonicalTable, text, opts) {
+      let encoding = opts && 'encoding' in opts ? opts.encoding : convert.UTF8;
+      let spaceToPlus = opts && 'spaceToPlus' in opts ? opts.spaceToPlus : false;
       function byteToHex(byte, buffer) {
         let hex = '0123456789ABCDEF';
         dart.dsend(buffer, 'writeCharCode', hex[dartx.codeUnitAt](dart.as(dart.dsend(byte, '>>', 4), int)));
@@ -3113,7 +3154,9 @@ dart_library.library('dart/core', null, /* Imports */[
       }
       return byte;
     }
-    static _uriDecode(text, {plusToSpace = false, encoding = convert.UTF8} = {}) {
+    static _uriDecode(text, opts) {
+      let plusToSpace = opts && 'plusToSpace' in opts ? opts.plusToSpace : false;
+      let encoding = opts && 'encoding' in opts ? opts.encoding : convert.UTF8;
       let simple = true;
       for (let i = 0; dart.notNull(i) < dart.notNull(text[dartx.length]) && dart.notNull(simple); i = dart.notNull(i) + 1) {
         let codeUnit = text[dartx.codeUnitAt](i);

--- a/lib/runtime/dart/isolate.js
+++ b/lib/runtime/dart/isolate.js
@@ -29,7 +29,9 @@ dart_library.library('dart/isolate', null, /* Imports */[
   });
   const _pause = Symbol('_pause');
   class Isolate extends core.Object {
-    Isolate(controlPort, {pauseCapability = null, terminateCapability = null} = {}) {
+    Isolate(controlPort, opts) {
+      let pauseCapability = opts && 'pauseCapability' in opts ? opts.pauseCapability : null;
+      let terminateCapability = opts && 'terminateCapability' in opts ? opts.terminateCapability : null;
       this.controlPort = controlPort;
       this.pauseCapability = pauseCapability;
       this.terminateCapability = terminateCapability;
@@ -37,7 +39,8 @@ dart_library.library('dart/isolate', null, /* Imports */[
     static get current() {
       return Isolate._currentIsolateCache;
     }
-    static spawn(entryPoint, message, {paused = false} = {}) {
+    static spawn(entryPoint, message, opts) {
+      let paused = opts && 'paused' in opts ? opts.paused : false;
       try {
         return _isolate_helper.IsolateNatives.spawnFunction(entryPoint, message, paused).then(dart.fn(msg => new Isolate(dart.as(dart.dindex(msg, 1), SendPort), {pauseCapability: dart.as(dart.dindex(msg, 2), Capability), terminateCapability: dart.as(dart.dindex(msg, 3), Capability)}), Isolate, [dart.dynamic]));
       } catch (e) {
@@ -46,7 +49,9 @@ dart_library.library('dart/isolate', null, /* Imports */[
       }
 
     }
-    static spawnUri(uri, args, message, {paused = false, packageRoot = null} = {}) {
+    static spawnUri(uri, args, message, opts) {
+      let paused = opts && 'paused' in opts ? opts.paused : false;
+      let packageRoot = opts && 'packageRoot' in opts ? opts.packageRoot : null;
       if (packageRoot != null)
         dart.throw(new core.UnimplementedError("packageRoot"));
       try {

--- a/lib/runtime/dart/js.js
+++ b/lib/runtime/dart/js.js
@@ -153,7 +153,8 @@ dart_library.library('dart/js', null, /* Imports */[
     _fromJs(jsObject) {
       super._fromJs(jsObject);
     }
-    apply(args, {thisArg = null} = {}) {
+    apply(args, opts) {
+      let thisArg = opts && 'thisArg' in opts ? opts.thisArg : null;
       return _convertToDart(this[_jsObject].apply(_convertToJS(thisArg), args == null ? null : core.List.from(args[dartx.map](_convertToJS))));
     }
   }

--- a/lib/runtime/dart/mirrors.js
+++ b/lib/runtime/dart/mirrors.js
@@ -97,7 +97,11 @@ dart_library.library('dart/mirrors', null, /* Imports */[
     constructors: () => ({Comment: [Comment, [core.String, core.String, core.bool]]})
   });
   class MirrorsUsed extends core.Object {
-    MirrorsUsed({symbols = null, targets = null, metaTargets = null, override = null} = {}) {
+    MirrorsUsed(opts) {
+      let symbols = opts && 'symbols' in opts ? opts.symbols : null;
+      let targets = opts && 'targets' in opts ? opts.targets : null;
+      let metaTargets = opts && 'metaTargets' in opts ? opts.metaTargets : null;
+      let override = opts && 'override' in opts ? opts.override : null;
       this.symbols = symbols;
       this.targets = targets;
       this.metaTargets = metaTargets;

--- a/tool/build_sdk.sh
+++ b/tool/build_sdk.sh
@@ -8,8 +8,11 @@ dart -c tool/patch_sdk.dart tool/input_sdk tool/generated_sdk
 
 echo "*** Compiling SDK to JavaScript"
 
+# TODO(ochafik): Re-enable named params destructuring when Atom supports it
+# (see https://github.com/dart-lang/dev_compiler/issues/396)
 dart -c bin/dartdevc.dart --no-source-maps --arrow-fn-bind-this --sdk-check \
     --force-compile -l warning --dart-sdk tool/generated_sdk -o lib/runtime/ \
+    --no-destructure-named-params \
     "$@" \
     dart:js dart:mirrors \
     > tool/sdk_expected_errors.txt || true


### PR DESCRIPTION
This is so the Atom plugin doesn't need to regenerate the SDK (it still
needs to be compiled with --no-destructure-named-params, though, until
Atom is updated to more ES6-compliant node/Chrome).