### PR TITLE
Update convert.js

### DIFF
--- a/lib/runtime/dart/convert.js
+++ b/lib/runtime/dart/convert.js
@@ -1050,7 +1050,7 @@ dart_library.library('dart/convert', null, /* Imports */[
     if (!(typeof source == 'string')) dart.throw(new core.ArgumentError(source));
     let parsed = null;
     try {
-      parsed = JSON.parse(source);
+      parsed = window.JSON.parse(source);
     } catch (e) {
       dart.throw(new core.FormatException(String(e)));
     }


### PR DESCRIPTION
Fix an exception, `'JSON.parse is not a function'`, where the compiled code is using dart:convert's `JSON`, when it wants to use the JS runtime's `JSON` (`JSON.parse`).

This works around an exception for me when trying to parse json. This is an FYI PR - I don't know where the fix should go when generating the code -