### PR TITLE
Update _operations.js

### DIFF
--- a/lib/runtime/dart/_operations.js
+++ b/lib/runtime/dart/_operations.js
@@ -176,6 +176,8 @@ dart_library.library('dart/_operations', null, /* Imports */[
         isSubtype(type, core.Map) && isSubtype(actual, core.Map) ||
         isSubtype(type, core.Function) && isSubtype(actual, core.Function) ||
         isSubtype(type, async.Stream) && isSubtype(actual, async.Stream) ||
+        isSubtype(type, async.StreamController) &&
+            isSubtype(actual, async.StreamController) ||
         isSubtype(type, async.StreamSubscription) &&
             isSubtype(actual, async.StreamSubscription)) {
       console.warn('Ignoring cast fail from ' + types.typeName(actual) +


### PR DESCRIPTION
Add StreamController to the list of ignored types in `_ignoreTypeFailure()`. I'm hitting this exception:

    Strong mode cast failure from _NoCallbackAsyncStreamController to StreamController<String>

though I don't know where _NoCallbackAsyncStreamController is coming from...


