### PR TITLE
Allow analyzer master failures in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ env:
   - TEST=coverage
   - TEST=transformer
   - TEST=node
+matrix:
+  allow_failures:
+    - env: ANALYZER=master


### PR DESCRIPTION
Doesn't fail the whole build, yet shows failures (cf. current failures: #471):
https://travis-ci.org/dart-lang/dev_compiler/builds/113155845