### PR TITLE
Fix transformer test

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -91,7 +91,7 @@ class BatchCompiler extends AbstractCompiler {
   String _runtimeOutputDir;
 
   /// Already compiled sources, so we don't check or compile them again.
-  final _compilationRecord = <LibraryElement, bool>{};
+  final _compilationRecord = new Map<LibraryElement, bool>.identity();
   bool _sdkCopied = false;
 
   bool _failure = false;


### PR DESCRIPTION
This fixes #476.

Travis is [broken since the latest analyzer sync](https://travis-ci.org/dart-lang/dev_compiler/builds/113485784): LibraryElement instances seem to collide in _compilationRecord map, causing libraries to not be generated (the first one is recorded as "true" / successful, which is picked up for all the others).