### PR TITLE
Deprecation text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # dev_compiler changelog
 
-## next release
+## 0.2.0
+- **This package is now deprecated** and will not be maintained going forward.
+  See [the README](https://pub.dartlang.org/packages/dev_compiler)
+  for details.
 - add support for AMD modules and make it the default.
 - precompile the SDK in AMD, CommonJS, and ES6 flavors.
 - legacy module format is deprecated.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
-dev_compiler
-============
+[![Gitter](https://img.shields.io/gitter/room/dart-lang/angular2.svg)](https://gitter.im/dart-lang/dev_compiler)
 
-[![Build Status](https://travis-ci.org/dart-lang/dev_compiler.svg?branch=master)](https://travis-ci.org/dart-lang/dev_compiler)
-[![Coverage Status](https://coveralls.io/repos/dart-lang/dev_compiler/badge.svg?branch=master)](https://coveralls.io/r/dart-lang/dev_compiler)
+**This package is deprecated.** It will not be maintained going forward.
 
-DDC has moved into the main [Dart SDK](https://github.com/dart-lang/sdk/tree/master/pkg/dev_compiler).  All further development will take place there.  This repository is now obsolete.
+The Dart development compiler (**dartdevc**, also known as _DDC_)
+is now part of the Dart SDK.
 
-Please file issues [there](https://github.com/dart-lang/sdk/issues?q=label%3Aarea-dev-compiler).
+
+Resources:
+
+* Documentation:
+  * [How to use dartdevc](https://webdev.dartlang.org/tools/dartdevc)
+  * [dartdevc FAQ](https://webdev.dartlang.org/tools/dartdevc/faq)
+* [Issue tracker](https://github.com/dart-lang/sdk/issues?q=label%3Aarea-dev-compiler)
+* [Source code](https://github.com/dart-lang/sdk/tree/master/pkg/dev_compiler)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,9 @@
 name: dev_compiler
 version: 0.2.0
-description: >
-  Experimental Dart to JavaScript compiler designed to create idiomatic,
-  readable JavaScript output.
+description: This package is deprecated. See the README for details.
 
 author: Dart Dev Compiler team <dev-compiler@dartlang.org>
-homepage: https://github.com/dart-lang/dev_compiler
+homepage: https://webdev.dartlang.org/tools/dartdevc
 
 dependencies:
   analyzer: ^0.28.0-alpha.1


### PR DESCRIPTION
Partial fix for https://github.com/dart-lang/sdk/issues/29911.

We might also want to update some code so that generated dartdocs have deprecation messages.